### PR TITLE
Explicitly set scrolling at the tableview to per-item

### DIFF
--- a/depthmapX/tableView.cpp
+++ b/depthmapX/tableView.cpp
@@ -49,6 +49,8 @@ tableView::tableView(QWidget *parent, QGraphDoc* p)
     setWindowIcon(QIcon(tr(":/images/cur/icon-1-5.png")));
     setWindowTitle(pDoc->m_base_title+":Table View");
 
+    setVerticalScrollMode(QAbstractItemView::ScrollPerItem);
+
 	m_protect_edit = false;
 }
 
@@ -84,7 +86,7 @@ void tableView::RedoTable()
 
 	  m_row_count = table.getRowCount();
 	  setRowCount(m_row_count);
-	  PrepareCache(0, m_curr_row);
+      PrepareCache(m_curr_row);
    }
 }
 
@@ -94,7 +96,7 @@ void tableView::scrollContentsBy(int dx, int dy)
 		QTableWidget::scrollContentsBy(dx, 0);
 		return;
 	}
-	PrepareCache(m_curr_row, m_curr_row - dy);
+    PrepareCache(m_curr_row - dy);
 	m_curr_row -= dy;
 	QTableWidget::scrollContentsBy(dx, dy);
 }
@@ -104,21 +106,23 @@ QSize tableView::sizeHint() const
 	return QSize(2000, 2000);
 }
 
-void tableView::PrepareCache(int from, int to)
+void tableView::PrepareCache(int to)
 {
 	in_update = 1;
 	QTableWidgetItem *Item;
 	const AttributeTable& table = pDoc->m_meta_graph->getAttributeTable();
 	AttributeIndex& index = table.m_display_index;
 
-	if(to+PG_COUNT >= m_row_count) return;
-	for (int i = 0; i < PG_COUNT; i++)
+    int diff = PG_COUNT;
+    if(to+PG_COUNT >= m_row_count) diff = m_row_count - to;
+    for (int i = 0; i < diff; i++)
 	{
 		for (int j = 0; j < m_column_count+1; j++)
 		{
 			if(!j)
 			{
-				if(Item = item(to+i, j))
+                Item = item(to+i, j);
+                if(Item)
 				{
 					if(table.isSelected(to+i)) Item->setCheckState(Qt::Checked);
 					else Item->setCheckState(Qt::Unchecked);
@@ -156,7 +160,7 @@ void tableView::itemChanged(QTableWidgetItem * item)
 		x.push_back(table.getRowKey(index[row].index));
 		pDoc->m_meta_graph->setSelSet(x);
 		pDoc->SetRedrawFlag(QGraphDoc::VIEW_ALL,QGraphDoc::REDRAW_POINTS, QGraphDoc::NEW_SELECTION, this);
-		PrepareCache(0, m_curr_row);
+        PrepareCache(m_curr_row);
 	}
 	else
 	{
@@ -192,7 +196,7 @@ void tableView::colum_Sort(int col_id)
 	{
 		pDoc->m_meta_graph->setDisplayedAttribute(col_id - 1);
 		clearContents();
-		PrepareCache(0, m_curr_row);
+        PrepareCache(m_curr_row);
 		return;
 
 		RedoTable();
@@ -223,7 +227,7 @@ int tableView::OnRedraw(int wParam, int lParam)
          }
          else {
             // redo the cache and redisplay
-            PrepareCache(0, m_curr_row);
+            PrepareCache(m_curr_row);
          }
       }
    }

--- a/depthmapX/tableView.cpp
+++ b/depthmapX/tableView.cpp
@@ -114,7 +114,10 @@ void tableView::PrepareCache(int to)
 	AttributeIndex& index = table.m_display_index;
 
     int diff = PG_COUNT;
-    if(to+PG_COUNT >= m_row_count) diff = m_row_count - to;
+    if(to+PG_COUNT >= m_row_count)
+    {
+        diff = m_row_count - to;
+    }
     for (int i = 0; i < diff; i++)
 	{
 		for (int j = 0; j < m_column_count+1; j++)

--- a/depthmapX/tableView.h
+++ b/depthmapX/tableView.h
@@ -48,7 +48,7 @@ protected:
 private:
 	int OnRedraw(int wParam, int lParam);
 	void RedoTable();
-	void PrepareCache(int from, int to);
+    void PrepareCache(int to);
 
     bool m_custom;
 };


### PR DESCRIPTION
Otherwise the default behaviour is different on mac (per-pixel) and windows (per-item), causing missing items only when scrolling on the mac. This will also now display the last few items when the item count is not a multiple of PG_COUNT

Also fixed a few warnings