### PR TITLE
Allow opening empty graphs

### DIFF
--- a/salalib/mgraph.cpp
+++ b/salalib/mgraph.cpp
@@ -2782,6 +2782,11 @@ int MetaGraph::read( const std::string& filename )
    else {
       FileProperties::setProperties("<unknown>","<unknown>","<unknown>","<unknown>");
    }
+   if (stream.eof()) {
+       // file is still ok, just empty
+       stream.close();
+       return OK;
+   }
    if (type == 'v') {
 
       conversion_required = true;


### PR DESCRIPTION
If File->New is selected and then the file is directly saved then the graph only contains an initial "properties" section. This graph can not be reopened by depthmap because an EOF is not expected there. This commit adds that EOF check