### PR TITLE
Allow negative numbers to be passed in the cli

### DIFF
--- a/depthmapXcli/parsingutils.h
+++ b/depthmapXcli/parsingutils.h
@@ -16,7 +16,8 @@
 #pragma once
 #define PASTE(arg) arg
 #define ENFORCE_ARGUMENT(flag, counter)\
-    if ( ++ PASTE(counter) >= argc || argv[ PASTE(counter)][0] == '-'  )\
+    if ( ++ PASTE(counter) >= argc \
+    || (argv[ PASTE(counter)][0] == '-' && !isdigit(argv[ PASTE(counter)][1]) && argv[ PASTE(counter)][1] != '.')  )\
     {\
         throw CommandLineException(flag  " requires an argument");\
     }\
@@ -26,7 +27,7 @@
 
 namespace depthmapX{
     inline bool has_only_digits_dots_commas(const std::string &s){
-        return s.find_first_not_of( "0123456789,." ) == std::string::npos;
+        return s.find_first_not_of( "0123456789,.-" ) == std::string::npos;
     }
 
     std::vector<double> parseAxialRadiusList(const std::string &radiusList);


### PR DESCRIPTION
Now numbers can be passed (i.e. for visprep -pp) that are negative (-0.1), as well as those that skip the leading 0 (-.1)