### PR TITLE
Copy, don't reference, the selection set

### DIFF
--- a/salalib/mgraph.cpp
+++ b/salalib/mgraph.cpp
@@ -569,7 +569,7 @@ int MetaGraph::makeIsovistPath(Communicator *communicator, double fov, bool simp
 
    bool first = true;
    if (makeBSPtree(communicator)) {
-      std::set<int>& selset = map->getSelSet();
+      std::set<int> selset = map->getSelSet();
       pqmap<int,SalaShape>& shapes = map->getAllShapes();
       for (auto& sel: selset) {
          SalaShape& path = shapes.value(sel);


### PR DESCRIPTION
Otherwise, if this is the first isovist created it will create a new layer (Isovists) which will in-turn reset the selection on the layer the path is located