### PR TITLE
Break out various parts and remove many paftl map instances 

### DIFF
--- a/depthmapX/3DView.cpp
+++ b/depthmapX/3DView.cpp
@@ -374,8 +374,10 @@ void Q3DView::ReloadLineData()
                else {
                   m_region = runion(m_region,superspacepix.at(i).at(j).getRegion());
                }
-               for (int k = 0; k < superspacepix.at(i).at(j).getAllShapes().size(); k++) {
-                  SalaShape& shape = superspacepix.at(i).at(j).getAllShapes().at(k);
+
+               auto refShapes = superspacepix.at(i).at(j).getAllShapes();
+               for (auto refShape: refShapes) {
+                  SalaShape& shape = refShape.second;
                   if (shape.isLine()) {
                      lines.push_back(shape.getLine());
                   }

--- a/depthmapX/3DView.cpp
+++ b/depthmapX/3DView.cpp
@@ -185,10 +185,10 @@ void Q3DView::timerEvent(QTimerEvent *event)
                      PixelRef pix = pointmap.pixelate(p); // note, take the pix before you scale!
                      p.normalScale(m_region);
                      m_mannequins[i].advance(p);
-                     size_t x = m_pixels.searchindex(pix);
-                     if (x != paftl::npos) {
-                        if (m_pixels[x].m_value < 10) {
-                           m_pixels[x].m_value += 1;
+                     auto iter = depthmapX::getMapAtIndex(m_pixels, pix);
+                     if (iter != m_pixels.end()) {
+                        if (iter->second.m_value < 10) {
+                           iter->second.m_value += 1;
                         }
                      }
                   }
@@ -206,10 +206,10 @@ void Q3DView::timerEvent(QTimerEvent *event)
                //
                // pretty coloured pixels
                PixelRef pix = m_agents[j].getNode();
-               size_t x = m_pixels.searchindex(pix);
-               if (x != paftl::npos) {
-                  if (m_pixels[x].m_value < 10) {
-                     m_pixels[x].m_value += 1;
+               auto iter = depthmapX::getMapAtIndex(m_pixels, pix);
+               if (iter != m_pixels.end()) {
+                  if (iter->second.m_value < 10) {
+                     iter->second.m_value += 1;
                   }
                }
             }
@@ -289,8 +289,8 @@ void Q3DView::DrawScene()
          }
       }
       else {
-         for (size_t i = 0; i < m_pixels.size(); i++) {
-            int& value = m_pixels[i].m_value;
+         for (auto pixel: m_pixels) {
+            int& value = pixel.second.m_value;
             if (value != -1) {
                if (pafrand() % 10000 == 0) {
                   value--;
@@ -298,7 +298,7 @@ void Q3DView::DrawScene()
                PafColor color;
                color.makeAxmanesque(float(value)/10.0f);
                glColor3f(color.redf(),color.greenf(),color.bluef());
-               Point2f& p = m_pixels[i].m_point;
+               Point2f& p = pixel.second.m_point;
                glPushMatrix();
                glTranslatef(p.x,p.y,0.0f);
                glVertexPointer(3, GL_FLOAT, 0, m_rect);
@@ -467,7 +467,7 @@ void Q3DView::ReloadPointData()
          PixelRef pix = table.getRowKey(i);
          Point2f p = map.depixelate(pix);
          p.normalScale(m_region);
-         m_pixels.add(pix,C3DPixelData(p));
+         m_pixels.insert(std::make_pair(pix,C3DPixelData(p)));
       }
    }
    else {
@@ -1199,8 +1199,8 @@ void Q3DView::OnToolsAgentsStop()
          m_mannequins[i].m_nextloc = m_mannequins[i].m_startloc;
       }
    }
-   for (int j = 0; j < m_pixels.size(); j++) {
-      m_pixels[j].m_value = -1;
+   for (auto pixel: m_pixels) {
+      pixel.second.m_value = -1;
    }
 }
 

--- a/depthmapX/3DView.cpp
+++ b/depthmapX/3DView.cpp
@@ -289,7 +289,7 @@ void Q3DView::DrawScene()
          }
       }
       else {
-         for (auto pixel: m_pixels) {
+         for (auto& pixel: m_pixels) {
             int& value = pixel.second.m_value;
             if (value != -1) {
                if (pafrand() % 10000 == 0) {
@@ -376,7 +376,7 @@ void Q3DView::ReloadLineData()
                }
 
                auto refShapes = superspacepix.at(i).at(j).getAllShapes();
-               for (auto refShape: refShapes) {
+               for (auto& refShape: refShapes) {
                   SalaShape& shape = refShape.second;
                   if (shape.isLine()) {
                      lines.push_back(shape.getLine());
@@ -1199,7 +1199,7 @@ void Q3DView::OnToolsAgentsStop()
          m_mannequins[i].m_nextloc = m_mannequins[i].m_startloc;
       }
    }
-   for (auto pixel: m_pixels) {
+   for (auto& pixel: m_pixels) {
       pixel.second.m_value = -1;
    }
 }

--- a/depthmapX/3DView.h
+++ b/depthmapX/3DView.h
@@ -116,7 +116,7 @@ public:
    QtRegion m_region;
    float *m_points;
    float m_rect[4][3];
-   pqmap<int,C3DPixelData> m_pixels;
+   std::map<int,C3DPixelData> m_pixels;
    //
    int m_pointcount;
    //

--- a/depthmapX/GraphDoc.cpp
+++ b/depthmapX/GraphDoc.cpp
@@ -2076,7 +2076,7 @@ void QGraphDoc::OnPushToLayer()
       int toplayerclass = (m_meta_graph->getViewClass() & MetaGraph::VIEWFRONT);
       std::string origin_layer;
       std::string origin_attribute;
-      pqmap<IntPair,std::string> names;
+      std::map<IntPair,std::string> names;
       // I'm just going to allow push from any layer to any other layer
       // (apart from VGA graphs, which cannot map onto themselves
       if (toplayerclass == MetaGraph::VIEWVGA) {
@@ -2107,20 +2107,20 @@ void QGraphDoc::OnPushToLayer()
       ShapeMaps<ShapeMap>& datamaps = m_meta_graph->getDataMaps();
       for (i = 0; i < datamaps.getMapCount(); i++) {
          if (toplayerclass != MetaGraph::VIEWDATA || i != datamaps.getDisplayedMapRef()) {
-            names.add(IntPair(MetaGraph::VIEWDATA,int(i)),std::string("Data Maps: ") + datamaps.getMap(i).getName());
+            names.insert(std::make_pair(IntPair(MetaGraph::VIEWDATA,int(i)),std::string("Data Maps: ") + datamaps.getMap(i).getName()));
          }
       }
       ShapeGraphs& shapegraphs = m_meta_graph->getShapeGraphs();
       for (i = 0; i < shapegraphs.getMapCount(); i++) {
          if (toplayerclass != MetaGraph::VIEWAXIAL || i != shapegraphs.getDisplayedMapRef()) {
-            names.add(IntPair(MetaGraph::VIEWAXIAL,int(i)),std::string("Shape Graphs: ") + shapegraphs.getMap(i).getName());
+            names.insert(std::make_pair(IntPair(MetaGraph::VIEWAXIAL,int(i)),std::string("Shape Graphs: ") + shapegraphs.getMap(i).getName()));
          }
       }
       for (i = 0; i < m_meta_graph->PointMaps::size(); i++) {
          // note 1: no VGA graph can push to another VGA graph (point onto point transforms)
          // note 2: I simply haven't written "axial" -> vga yet, not that it can't be possible (e.g., "axial" could actually be a convex map)
          if (toplayerclass != MetaGraph::VIEWVGA && toplayerclass != MetaGraph::VIEWAXIAL) {
-            names.add(IntPair(MetaGraph::VIEWVGA,int(i)),std::string("Visibility Graphs: ") + m_meta_graph->PointMaps::at(i).getName());
+            names.insert(std::make_pair(IntPair(MetaGraph::VIEWVGA,int(i)),std::string("Visibility Graphs: ") + m_meta_graph->PointMaps::at(i).getName()));
          }
       }
       CPushDialog dlg(names);
@@ -2130,7 +2130,7 @@ void QGraphDoc::OnPushToLayer()
          m_communicator = new CMSCommunicator;   // dummy value to prevent draw while this operation is in progress
          // now have to separate vga and axial layers again:
          int sel = dlg.m_layer_selection;
-         IntPair dest = names.key(sel);
+         IntPair dest = depthmapX::getMapAtIndex(names, sel)->first;
 //         CWaitCursor c;
          m_meta_graph->pushValuesToLayer(dest.a, dest.b, dlg.m_function, dlg.m_count_intersections);
          delete m_communicator;

--- a/depthmapX/PushDialog.cpp
+++ b/depthmapX/PushDialog.cpp
@@ -15,7 +15,7 @@
 
 #include "PushDialog.h"
 
-CPushDialog::CPushDialog(pqmap<IntPair,std::string>& names, QWidget *parent)
+CPushDialog::CPushDialog(std::map<IntPair, string> &names, QWidget *parent)
 : QDialog(parent)
 {
 	setupUi(this);
@@ -27,8 +27,8 @@ CPushDialog::CPushDialog(pqmap<IntPair,std::string>& names, QWidget *parent)
 
 	m_function = 0;
 
-	for (size_t i = 0; i < names.size(); i++) {
-		m_names.push_back(names.value(i));
+    for (auto name: names) {
+        m_names.push_back(name.second);
 	}
 }
 

--- a/depthmapX/PushDialog.cpp
+++ b/depthmapX/PushDialog.cpp
@@ -27,7 +27,7 @@ CPushDialog::CPushDialog(std::map<IntPair, string> &names, QWidget *parent)
 
 	m_function = 0;
 
-    for (auto name: names) {
+    for (auto& name: names) {
         m_names.push_back(name.second);
 	}
 }

--- a/depthmapX/PushDialog.h
+++ b/depthmapX/PushDialog.h
@@ -23,7 +23,7 @@ class CPushDialog : public QDialog, public Ui::CPushDialog
 {
 	Q_OBJECT
 public:
-    CPushDialog(pqmap<IntPair,std::string>& names, QWidget *parent = 0);
+    CPushDialog(std::map<IntPair,std::string>& names, QWidget *parent = 0);
 	int		m_layer_selection;
 	QString	m_origin_attribute;
 	QString	m_origin_layer;

--- a/depthmapX/glview.cpp
+++ b/depthmapX/glview.cpp
@@ -379,7 +379,7 @@ void GLView::mouseReleaseEvent(QMouseEvent *event)
                     if (m_pDoc.m_meta_graph->getViewClass() & MetaGraph::VIEWVGA) {
                         selectionCentre = m_pDoc.m_meta_graph->getDisplayedPointMap().depixelate(*selectedSet.begin());
                     } else if (m_pDoc.m_meta_graph->getViewClass() & MetaGraph::VIEWAXIAL) {
-                        selectionCentre = m_pDoc.m_meta_graph->getDisplayedShapeGraph().getAllShapes()[*selectedSet.begin()].getCentroid();
+                        selectionCentre = m_pDoc.m_meta_graph->getDisplayedShapeGraph().getAllShapes().find(*selectedSet.begin())->second.getCentroid();
                     }
                 }
                 m_tempFirstPoint = selectionCentre;
@@ -425,7 +425,7 @@ void GLView::mouseReleaseEvent(QMouseEvent *event)
                     }
                 } else if (m_pDoc.m_meta_graph->getViewClass() & MetaGraph::VIEWAXIAL) {
                     const auto& selectedSet = m_pDoc.m_meta_graph->getSelSet();
-                    Point2f selectionCentre = m_pDoc.m_meta_graph->getDisplayedShapeGraph().getAllShapes()[*selectedSet.begin()].getCentroid();
+                    Point2f selectionCentre = m_pDoc.m_meta_graph->getDisplayedShapeGraph().getAllShapes().find(*selectedSet.begin())->second.getCentroid();
                     m_tempFirstPoint = selectionCentre;
                     m_tempSecondPoint = selectionCentre;
                     m_mouseMode = MOUSE_MODE_UNJOIN | MOUSE_MODE_SECOND_POINT;

--- a/depthmapX/mainwindow.cpp
+++ b/depthmapX/mainwindow.cpp
@@ -2239,9 +2239,9 @@ void MainWindow::RedoPlotViewMenu(QGraphDoc* pDoc)
              int displayed_ref = map.getDisplayedAttribute();
 
              const AttributeTable& table = map.getAttributeTable();
-             m_view_map_entries.add(0, "Ref Number");
+             m_view_map_entries.insert(std::make_pair(0, "Ref Number"));
              for (int i = 0; i < table.getColumnCount(); i++) {
-                m_view_map_entries.add(i+1, table.getColumnName(i));
+                m_view_map_entries.insert(std::make_pair(i+1, table.getColumnName(i)));
                 if (map.getDisplayedAttribute() == i) {
                    curr_j = i + 1;
                 }
@@ -2251,10 +2251,10 @@ void MainWindow::RedoPlotViewMenu(QGraphDoc* pDoc)
              // using attribute tables is very, very simple...
              const ShapeGraph& map = pDoc->m_meta_graph->getDisplayedShapeGraph();
              const AttributeTable& table = map.getAttributeTable();
-             m_view_map_entries.add(0, "Ref Number");
+             m_view_map_entries.insert(std::make_pair(0, "Ref Number"));
              curr_j = 0;
              for (int i = 0; i < table.getColumnCount(); i++) {
-                m_view_map_entries.add(i+1, table.getColumnName(i));
+                m_view_map_entries.insert(std::make_pair(i+1, table.getColumnName(i)));
                 if (map.getDisplayedAttribute() == i) {
                    curr_j = i + 1;
                 }
@@ -2264,10 +2264,10 @@ void MainWindow::RedoPlotViewMenu(QGraphDoc* pDoc)
              // using attribute tables is very, very simple...
              const ShapeMap& map = pDoc->m_meta_graph->getDisplayedDataMap();
              const AttributeTable& table = map.getAttributeTable();
-             m_view_map_entries.add(0, "Ref Number");
+             m_view_map_entries.insert(std::make_pair(0, "Ref Number"));
              curr_j = 0;
              for (int i = 0; i < table.getColumnCount(); i++) {
-                m_view_map_entries.add(i+1, table.getColumnName(i));
+                m_view_map_entries.insert(std::make_pair(i+1, table.getColumnName(i)));
                 if (map.getDisplayedAttribute() == i) {
                    curr_j = i + 1;
                 }
@@ -2280,10 +2280,12 @@ void MainWindow::RedoPlotViewMenu(QGraphDoc* pDoc)
    x_coord->clear();
    y_coord->clear();
 
-   for (size_t i = 0; i < m_view_map_entries.size(); i++) {
-      if (curr_j == m_view_map_entries.key(i)) cur_sel = (int) i;
-      x_coord->addItem( QString(m_view_map_entries.value(i).c_str()) );
-      y_coord->addItem( QString(m_view_map_entries.value(i).c_str()) );
+   int i = -1;
+   for (auto view_map_entry: m_view_map_entries) {
+      i++;
+      if (curr_j == view_map_entry.first) cur_sel = (int) i;
+      x_coord->addItem( QString(view_map_entry.second.c_str()) );
+      y_coord->addItem( QString(view_map_entry.second.c_str()) );
    }
 
    t = ((QPlotView*)pDoc->m_view[QGraphDoc::VIEW_SCATTER])->curr_y;

--- a/depthmapX/mainwindow.cpp
+++ b/depthmapX/mainwindow.cpp
@@ -1294,9 +1294,9 @@ void MainWindow::OnSelchangingTree(QTreeWidgetItem* hItem, int col)
     bool update = false;
 
     // look it up in the table to see what to do:
-    size_t n = m_treegraphmap.searchindex(hItem);
-    if (n != paftl::npos) {
-        ItemTreeEntry entry = m_treegraphmap.value(n);
+    auto iter = m_treegraphmap.find(hItem);
+    if (iter != m_treegraphmap.end()) {
+        ItemTreeEntry entry = iter->second;
         bool remenu = false;
         if (entry.m_cat != -1) {
             if (entry.m_subcat == -1) {
@@ -1394,9 +1394,9 @@ void MainWindow::OnSelchangingTree(QTreeWidgetItem* hItem, int col)
         }
     }
     else {
-        size_t n = m_treedrawingmap.searchindex(hItem);
-        if (n != paftl::npos) {
-            ItemTreeEntry entry = m_treedrawingmap.value(n);
+        auto iter = m_treedrawingmap.find(hItem);
+        if (iter != m_treedrawingmap.end()) {
+            ItemTreeEntry entry = iter->second;
             if (entry.m_subcat != -1) {
                 if (graph->getLineLayer(entry.m_cat,entry.m_subcat).isShown()) {
                     graph->getLineLayer(entry.m_cat,entry.m_subcat).setShow(false);
@@ -1419,9 +1419,9 @@ void MainWindow::SetGraphTreeChecks()
     in_FocusGraph = true;
     MetaGraph *graph = m_treeDoc->m_meta_graph;
     int viewclass = graph->getViewClass();
-    for (size_t i = 0; i < m_treegraphmap.size(); i++) {
-        QTreeWidgetItem* key = m_treegraphmap.key(i);
-        ItemTreeEntry entry = m_treegraphmap[i];
+    for (auto item: m_treegraphmap) {
+        QTreeWidgetItem* key = item.first;
+        ItemTreeEntry entry = item.second;
         int checkstyle = 7;
         if (entry.m_cat != -1) {
             if (entry.m_subcat == -1) {
@@ -1530,14 +1530,14 @@ void MainWindow::SetDrawingTreeChecks()
 {
     MetaGraph *graph = m_treeDoc->m_meta_graph;
     int viewclass = graph->getViewClass();
-    for (size_t i = 0; i < m_treedrawingmap.size(); i++) {
-        ItemTreeEntry entry = m_treedrawingmap[i];
+    for (auto iter: m_treedrawingmap) {
+        ItemTreeEntry entry = iter.second;
         if (entry.m_subcat != -1) {
             if (graph->getLineLayer(entry.m_cat,entry.m_subcat).isShown()) {
-                  m_treedrawingmap.key(i)->setIcon(0, m_tree_icon[12]);
+                  iter.first->setIcon(0, m_tree_icon[12]);
             }
             else {
-                  m_treedrawingmap.key(i)->setIcon(0, m_tree_icon[13]);
+                  iter.first->setIcon(0, m_tree_icon[13]);
             }
         }
     }
@@ -1569,7 +1569,7 @@ void MainWindow::MakeGraphTree()
             QTreeWidgetItem* hItem = m_indexWidget->addNewRootFolder(tr("Visibility Graphs"));
             hItem->setIcon(0, m_tree_icon[0]);
             ItemTreeEntry entry(0,-1,-1);
-            m_treegraphmap.add(hItem, entry);
+            m_treegraphmap.insert(std::make_pair(hItem, entry));
             m_treeroots[0] = hItem;
         }
         QTreeWidgetItem* hItem = m_treeroots[0]->child(0);
@@ -1579,12 +1579,12 @@ void MainWindow::MakeGraphTree()
                 hItem = m_indexWidget->addNewFolder(name, m_treeroots[0]);
                 hItem->setCheckState(0, Qt::Unchecked);
                 ItemTreeEntry entry(0,(short)i,-1);
-                m_treegraphmap.add(hItem,entry);
+                m_treegraphmap.insert(std::make_pair(hItem,entry));
                 {
                     QTreeWidgetItem* hNewItem = m_indexWidget->addNewItem("Editable", 0);
                     hNewItem->setCheckState(0, Qt::Unchecked);
                     ItemTreeEntry newentry = ItemTreeEntry(0,(short)i,-2);
-                    m_treegraphmap.add(hNewItem, newentry);
+                    m_treegraphmap.insert(std::make_pair(hNewItem, newentry));
                 }
             }
             else if (hItem->text(0) != name) hItem->setText(0, name);
@@ -1599,7 +1599,10 @@ void MainWindow::MakeGraphTree()
     }
     else if (m_treeroots[0]) {
         m_treeroots[0]->removeChild(m_treeroots[0]);
-        m_treegraphmap.remove(m_treeroots[0]);
+        auto iter = m_treegraphmap.find(m_treeroots[0]);
+        if(iter != m_treegraphmap.end()) {
+            m_treegraphmap.erase(iter);
+        }
         m_treeroots[0] = NULL;
     }
 
@@ -1608,7 +1611,7 @@ void MainWindow::MakeGraphTree()
             QTreeWidgetItem* hItem = m_indexWidget->addNewRootFolder(tr("Shape Graphs"));
             hItem->setIcon(0, m_tree_icon[1]);
             ItemTreeEntry entry(1,-1,-1);
-            m_treegraphmap.add(hItem, entry);
+            m_treegraphmap.insert(std::make_pair(hItem, entry));
             m_treeroots[1] = hItem;
         }
         QTreeWidgetItem* hItem = m_treeroots[1]->child(0);
@@ -1618,12 +1621,12 @@ void MainWindow::MakeGraphTree()
                 hItem = m_indexWidget->addNewFolder(name, m_treeroots[1]);
                 hItem->setCheckState(0, Qt::Unchecked);
                 ItemTreeEntry entry(1,(short)i,-1);
-                m_treegraphmap.add(hItem,entry);
+                m_treegraphmap.insert(std::make_pair(hItem,entry));
                 {
                     QTreeWidgetItem* hNewItem = m_indexWidget->addNewItem("Editable", 0);
                     hNewItem->setCheckState(0, Qt::Unchecked);
                     ItemTreeEntry newentry = ItemTreeEntry(1,(short)i,-2);
-                    m_treegraphmap.add(hNewItem, newentry);
+                    m_treegraphmap.insert(std::make_pair(hNewItem, newentry));
                 }
             }
             else if (hItem->text(0) != name) hItem->setText(0, name);
@@ -1634,7 +1637,7 @@ void MainWindow::MakeGraphTree()
                 if (hNewItem == NULL) {
                     hNewItem = m_indexWidget->addNewItem(name, 0);
                     ItemTreeEntry entry(1,(short)i,j);
-                    m_treegraphmap.add(hNewItem,entry);
+                    m_treegraphmap.insert(std::make_pair(hNewItem,entry));
                 }
                 else if (hNewItem->text(0) != name) hNewItem->setText(0, name);
                 hNewItem = hNewItem->child(1);
@@ -1650,7 +1653,10 @@ void MainWindow::MakeGraphTree()
     }
     else if (m_treeroots[1]) {
         m_treeroots[1]->removeChild(m_treeroots[1]);
-        m_treegraphmap.remove(m_treeroots[1]);
+        auto iter = m_treegraphmap.find(m_treeroots[1]);
+        if(iter != m_treegraphmap.end()) {
+            m_treegraphmap.erase(iter);
+        }
         m_treeroots[1] = NULL;
     }
 
@@ -1659,7 +1665,7 @@ void MainWindow::MakeGraphTree()
             QTreeWidgetItem* hItem = m_indexWidget->addNewRootFolder(tr("Data Maps"));
             hItem->setIcon(0, m_tree_icon[2]);
             ItemTreeEntry entry(2,-1,-1);
-            m_treegraphmap.add(hItem, entry);
+            m_treegraphmap.insert(std::make_pair(hItem, entry));
             m_treeroots[2] = hItem;
         }
         QTreeWidgetItem* hItem = m_treeroots[2]->child(0);
@@ -1670,12 +1676,12 @@ void MainWindow::MakeGraphTree()
                 hItem = m_indexWidget->addNewFolder(name, m_treeroots[2]);
                 hItem->setCheckState(0, Qt::Unchecked);
                 ItemTreeEntry entry(2,(short)i,-1);
-                m_treegraphmap.add(hItem, entry);
+                m_treegraphmap.insert(std::make_pair(hItem, entry));
                 {
                     hItem = m_indexWidget->addNewItem(tr("Editable"), 0);
                     hItem->setCheckState(0, Qt::Unchecked);
                     ItemTreeEntry newentry = ItemTreeEntry(2,(short)i,-2);
-                    m_treegraphmap.add(hItem, newentry);
+                    m_treegraphmap.insert(std::make_pair(hItem, newentry));
                 }
             }
             else if (hItem->text(0) != name) hItem->setText(0, name);
@@ -1688,7 +1694,7 @@ void MainWindow::MakeGraphTree()
                     hNewItem = m_indexWidget->addNewItem(name, 0);
                     hNewItem->setCheckState(0, Qt::Unchecked);
                     ItemTreeEntry entry(2,(short)i,j);
-                    m_treegraphmap.add(hNewItem,entry);
+                    m_treegraphmap.insert(std::make_pair(hNewItem,entry));
                 }
                 else if (hNewItem->text(0) != name) hNewItem->setText(0, name);
                 hNewItem = hNewItem->child(0);
@@ -1704,7 +1710,10 @@ void MainWindow::MakeGraphTree()
     }
     else if (m_treeroots[2]) {
         m_treeroots[2]->removeChild(m_treeroots[2]);
-        m_treegraphmap.remove(m_treeroots[2]);
+        auto iter = m_treegraphmap.find(m_treeroots[2]);
+        if(iter != m_treegraphmap.end()) {
+            m_treegraphmap.erase(iter);
+        }
         m_treeroots[2] = NULL;
     }
 
@@ -1726,14 +1735,14 @@ void MainWindow::MakeDrawingTree()
         QTreeWidgetItem* root = m_indexWidget->addNewRootFolder(tr("Drawing Layers"));
         root->setIcon(0, m_tree_icon[4]);
         ItemTreeEntry entry(4,0,-1);
-        m_treedrawingmap.add(root,entry);
+        m_treedrawingmap.insert(std::make_pair(root,entry));
         m_treeroots[4] = root;
         for (int i = 0; i < m_treeDoc->m_meta_graph->getLineFileCount(); i++) {
 
             QTreeWidgetItem* subroot = m_indexWidget->addNewFolder(QString(m_treeDoc->m_meta_graph->getLineFileName(i).c_str()), m_treeroots[4]);
             subroot->setIcon(0, m_tree_icon[8]);
             ItemTreeEntry entry(4,i,-1);
-            m_treedrawingmap.add(subroot,entry);
+            m_treedrawingmap.insert(std::make_pair(subroot,entry));
 
             for (int j = 0; j < m_treeDoc->m_meta_graph->getLineLayerCount(i); j++) {
                 QString name(m_treeDoc->m_meta_graph->getLineLayer(i,j).getName().c_str());
@@ -1745,7 +1754,7 @@ void MainWindow::MakeDrawingTree()
                     hItem->setCheckState(0, Qt::Unchecked);
                 }
                 ItemTreeEntry entry(4,i,j);
-                m_treedrawingmap.add(hItem,entry);
+                m_treedrawingmap.insert(std::make_pair(hItem,entry));
             }
         }
     }

--- a/depthmapX/mainwindow.cpp
+++ b/depthmapX/mainwindow.cpp
@@ -1419,7 +1419,7 @@ void MainWindow::SetGraphTreeChecks()
     in_FocusGraph = true;
     MetaGraph *graph = m_treeDoc->m_meta_graph;
     int viewclass = graph->getViewClass();
-    for (auto item: m_treegraphmap) {
+    for (auto& item: m_treegraphmap) {
         QTreeWidgetItem* key = item.first;
         ItemTreeEntry entry = item.second;
         int checkstyle = 7;
@@ -1530,7 +1530,7 @@ void MainWindow::SetDrawingTreeChecks()
 {
     MetaGraph *graph = m_treeDoc->m_meta_graph;
     int viewclass = graph->getViewClass();
-    for (auto iter: m_treedrawingmap) {
+    for (auto& iter: m_treedrawingmap) {
         ItemTreeEntry entry = iter.second;
         if (entry.m_subcat != -1) {
             if (graph->getLineLayer(entry.m_cat,entry.m_subcat).isShown()) {
@@ -2290,7 +2290,7 @@ void MainWindow::RedoPlotViewMenu(QGraphDoc* pDoc)
    y_coord->clear();
 
    int i = -1;
-   for (auto view_map_entry: m_view_map_entries) {
+   for (auto& view_map_entry: m_view_map_entries) {
       i++;
       if (curr_j == view_map_entry.first) cur_sel = (int) i;
       x_coord->addItem( QString(view_map_entry.second.c_str()) );

--- a/depthmapX/mainwindow.h
+++ b/depthmapX/mainwindow.h
@@ -252,8 +252,8 @@ private:
     std::map<int, std::string> m_view_map_entries;
 
     pvector<bool> m_attribute_locked;
-    pmap<QTreeWidgetItem*, ItemTreeEntry> m_treegraphmap;
-    pmap<QTreeWidgetItem*, ItemTreeEntry> m_treedrawingmap;
+    std::map<QTreeWidgetItem*, ItemTreeEntry> m_treegraphmap;
+    std::map<QTreeWidgetItem*, ItemTreeEntry> m_treedrawingmap;
     QTreeWidgetItem* m_topgraph;
     QTreeWidgetItem* m_backgraph;
     QTreeWidgetItem* m_treeroots[5];

--- a/depthmapX/mainwindow.h
+++ b/depthmapX/mainwindow.h
@@ -249,7 +249,7 @@ private:
 //////////////////////////////////////////////////////
 //	treeContorl
     QVector<QIcon> m_tree_icon;
-    pqmap<int, std::string> m_view_map_entries;
+    std::map<int, std::string> m_view_map_entries;
 
     pvector<bool> m_attribute_locked;
     pmap<QTreeWidgetItem*, ItemTreeEntry> m_treegraphmap;

--- a/genlib/containerutils.h
+++ b/genlib/containerutils.h
@@ -32,4 +32,22 @@ void addIfNotExists(std::vector<T> &vec, T element) {
         vec.push_back(element);
 }
 
+template<typename K, typename V>
+typename std::map<K, V>::const_iterator getMapAtIndex(const std::map<K, V> &m, int idx) {
+    auto iter = m.begin();
+    std::advance(iter, idx);
+    return iter;
+}
+
+template<typename K, typename V>
+int findIndexFromKey(const std::map<K, V> &m, K key) {
+    return std::distance(m.begin(), m.find(key));
+}
+
+template<typename K, typename V>
+int insertAndGetIndex(std::map<K, V> &m, K key, V value) {
+    m.insert(std::make_pair(key, value));
+    return findIndexFromKey(m, key);
+}
+
 }

--- a/genlib/containerutils.h
+++ b/genlib/containerutils.h
@@ -40,8 +40,16 @@ typename std::map<K, V>::const_iterator getMapAtIndex(const std::map<K, V> &m, i
 }
 
 template<typename K, typename V>
+typename std::map<K, V>::iterator getMapAtIndex(std::map<K, V> &m, int idx) {
+    auto iter = m.begin();
+    std::advance(iter, idx);
+    return iter;
+}
+
+template<typename K, typename V>
 int findIndexFromKey(const std::map<K, V> &m, K key) {
-    return std::distance(m.begin(), m.find(key));
+    auto iter = m.find(key);
+    return iter == m.end() ? -1 : std::distance(m.begin(), iter);
 }
 
 template<typename K, typename V>

--- a/genlib/legacyconverters.h
+++ b/genlib/legacyconverters.h
@@ -1,4 +1,5 @@
 // Copyright (C) 2017 Christian Sailer
+// Copyright (C) 2018 Petros Koutsolampros
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -16,6 +17,7 @@
 #pragma once
 #include <vector>
 #include <algorithm>
+#include <map>
 #include "paftl.h"
 
 namespace genshim
@@ -54,5 +56,29 @@ namespace genshim
         pqvector<T> pvec;
         std::for_each(vec.begin(), vec.end(), [&pvec](const T& val)->void{pvec.push_back(val);});
         return pvec;
+    }
+
+    /**
+     * Convert a pmap to a std::map (preserving the order of elements)
+     * This is expensive as it copies every single element
+     */
+    template<class K, class V> std::map<K, V> toSTLMap(pmap<K, V> &pm)
+    {
+        std::map<K, V> m;
+        for(int i = 0; i < pm.size(); i++) {
+            m.insert(std::make_pair(pm.key(i), pm.value(i)));
+        }
+        return m;
+    }
+
+    /**
+     * Convert a std::map to a pmap (preserving the order of elements)
+     * This is expensive as it copies every single element
+     */
+    template<class K, class V> pmap<K, V> toPMap(const std::map<K, V> &m)
+    {
+        pmap<K, V> pm;
+        for(auto pair: m) { pm.add(pair.first, pair.second); }
+        return pm;
     }
 }

--- a/genlib/legacyconverters.h
+++ b/genlib/legacyconverters.h
@@ -78,7 +78,7 @@ namespace genshim
     template<class K, class V> pmap<K, V> toPMap(const std::map<K, V> &m)
     {
         pmap<K, V> pm;
-        for(auto pair: m) { pm.add(pair.first, pair.second); }
+        for (auto& pair: m) { pm.add(pair.first, pair.second); }
         return pm;
     }
 }

--- a/salaTest/testmapinfodata.cpp
+++ b/salaTest/testmapinfodata.cpp
@@ -131,21 +131,21 @@ TEST_CASE("Complete proper MapInfo file", "")
     std::stringstream midstream(middata);
     REQUIRE(mapinfodata.import(mifstream, midstream, shapeMap) == MINFO_OK);
 
-    pqmap<int, SalaShape> shapes = shapeMap.getAllShapes();
+    std::map<int, SalaShape> shapes = shapeMap.getAllShapes();
     REQUIRE(shapes.size() == 3);
-    REQUIRE(shapes[0].isLine());
-    REQUIRE(shapes[0].getLine().ax() == Approx(534014.29).epsilon(EPSILON));
-    REQUIRE(shapes[0].getLine().ay() == Approx(182533.33).epsilon(EPSILON));
-    REQUIRE(shapes[0].getLine().bx() == Approx(535008.52).epsilon(EPSILON));
-    REQUIRE(shapes[0].getLine().by() == Approx(182764.11).epsilon(EPSILON));
-    REQUIRE(shapes[1].isLine());
-    REQUIRE(shapes[1].getLine().ax() == Approx(533798.68).epsilon(EPSILON));
-    REQUIRE(shapes[1].getLine().ay() == Approx(183094.69).epsilon(EPSILON));
-    REQUIRE(shapes[1].getLine().bx() == Approx(534365.48).epsilon(EPSILON));
-    REQUIRE(shapes[1].getLine().by() == Approx(183159.01).epsilon(EPSILON));
-    REQUIRE(shapes[2].isPoint());
-    REQUIRE(shapes[2].getPoint().x == Approx(534014.29).epsilon(EPSILON));
-    REQUIRE(shapes[2].getPoint().y == Approx(182533.33).epsilon(EPSILON));
+    REQUIRE(depthmapX::getMapAtIndex(shapes, 0)->second.isLine());
+    REQUIRE(depthmapX::getMapAtIndex(shapes, 0)->second.getLine().ax() == Approx(534014.29).epsilon(EPSILON));
+    REQUIRE(depthmapX::getMapAtIndex(shapes, 0)->second.getLine().ay() == Approx(182533.33).epsilon(EPSILON));
+    REQUIRE(depthmapX::getMapAtIndex(shapes, 0)->second.getLine().bx() == Approx(535008.52).epsilon(EPSILON));
+    REQUIRE(depthmapX::getMapAtIndex(shapes, 0)->second.getLine().by() == Approx(182764.11).epsilon(EPSILON));
+    REQUIRE(depthmapX::getMapAtIndex(shapes, 1)->second.isLine());
+    REQUIRE(depthmapX::getMapAtIndex(shapes, 1)->second.getLine().ax() == Approx(533798.68).epsilon(EPSILON));
+    REQUIRE(depthmapX::getMapAtIndex(shapes, 1)->second.getLine().ay() == Approx(183094.69).epsilon(EPSILON));
+    REQUIRE(depthmapX::getMapAtIndex(shapes, 1)->second.getLine().bx() == Approx(534365.48).epsilon(EPSILON));
+    REQUIRE(depthmapX::getMapAtIndex(shapes, 1)->second.getLine().by() == Approx(183159.01).epsilon(EPSILON));
+    REQUIRE(depthmapX::getMapAtIndex(shapes, 2)->second.isPoint());
+    REQUIRE(depthmapX::getMapAtIndex(shapes, 2)->second.getPoint().x == Approx(534014.29).epsilon(EPSILON));
+    REQUIRE(depthmapX::getMapAtIndex(shapes, 2)->second.getPoint().y == Approx(182533.33).epsilon(EPSILON));
 
     AttributeTable att = shapeMap.getAttributeTable();
     REQUIRE(att.getColumnCount() == 2);

--- a/salalib/MapInfoData.cpp
+++ b/salalib/MapInfoData.cpp
@@ -291,10 +291,12 @@ bool MapInfoData::exportFile(ostream& miffile, ostream& midfile, const ShapeMap&
 
    miffile.precision(16);
 
-   for (size_t i = 0; i < map.m_shapes.size(); i++) {
+   int i = -1;
+   for (auto shape: map.m_shapes) {
+      i++;
       // note, attributes must align for this:
       if (map.getAttributeTable().isVisible(i)) {
-         const SalaShape& poly = map.m_shapes[i];
+         const SalaShape& poly = shape.second;
          if (poly.isPoint()) {
             miffile << "POINT " << poly.getPoint().x << " " << poly.getPoint().y << endl;
             miffile << "    SYMBOL (32,0,10)" << endl;

--- a/salalib/MapInfoData.cpp
+++ b/salalib/MapInfoData.cpp
@@ -292,7 +292,7 @@ bool MapInfoData::exportFile(ostream& miffile, ostream& midfile, const ShapeMap&
    miffile.precision(16);
 
    int i = -1;
-   for (auto shape: map.m_shapes) {
+   for (auto& shape: map.m_shapes) {
       i++;
       // note, attributes must align for this:
       if (map.getAttributeTable().isVisible(i)) {

--- a/salalib/axialmap.cpp
+++ b/salalib/axialmap.cpp
@@ -100,15 +100,16 @@ AxialVertex AxialPolygons::makeVertex(const AxialVertexKey& vertexkey, const Poi
    Point2f o = av.m_point - av.m_openspace;
 
    // using an anglemap means that there are now no anti-clockwise vertices...
-   pmap<double,int> anglemap;
+   std::map<double,int> anglemap;
    for (size_t i = 0; i < pointlist.size(); i++) {
-      anglemap.add( angle(openspace,av.m_point,pointlist[i]), i );
+      anglemap.insert(std::make_pair( angle(openspace,av.m_point,pointlist[i]), i ));
    }
 
-   av.m_ref_a = anglemap.head();
-   av.m_ref_a = anglemap.tail();
-   Point2f a = av.m_point - pointlist.at( anglemap.head() );
-   Point2f b = pointlist.at( anglemap.tail() ) - av.m_point;
+   av.m_ref_a = anglemap.begin()->second;
+   // TODO: is this supposed to be av.m_ref_b?
+   av.m_ref_a = anglemap.rbegin()->second;
+   Point2f a = av.m_point - pointlist.at( anglemap.begin()->second );
+   Point2f b = pointlist.at( anglemap.rbegin()->second ) - av.m_point;
    av.m_a = a;
    av.m_b = b;
    a.normalise();
@@ -1255,7 +1256,7 @@ int ShapeGraphs::convertDrawingToAxial(Communicator *comm, const std::string& na
 
    QtRegion region;
    std::map<int,Line> lines;  // map required for tidy lines, otherwise acts like vector
-   pmap<int,int> layers;  // this is used to say which layer it originated from
+   std::map<int,int> layers;  // this is used to say which layer it originated from
 
    bool recordlayer = false;
 
@@ -1275,18 +1276,18 @@ int ShapeGraphs::convertDrawingToAxial(Communicator *comm, const std::string& na
                 SalaShape& shape = refShape.second;
                if (shape.isLine()) {
                   lines.insert(std::make_pair(count,shape.getLine()));
-                  layers.add(count,j);
+                  layers.insert(std::make_pair(count,j));
                   count++;
                }
                else if (shape.isPolyLine() || shape.isPolygon()) {
                   for (size_t n = 0; n < shape.size() - 1; n++) {
                      lines.insert(std::make_pair(count,Line(shape[n],shape[n+1])));
-                     layers.add(count,j);
+                     layers.insert(std::make_pair(count,j));
                      count++;
                   }
                   if (shape.isPolygon()) {
                      lines.insert(std::make_pair(count,Line(shape.tail(),shape.head())));
-                     layers.add(count,j);
+                     layers.insert(std::make_pair(count,j));
                      count++;
                   }
                }
@@ -1357,7 +1358,7 @@ int ShapeGraphs::convertDrawingToAxial(Communicator *comm, const std::string& na
       int k = -1;
       for (auto line: lines) {
          k++;
-         table.setValue(k,col,float(layers.search(line.first)));
+         table.setValue(k,col,float(layers.find(line.first)->second));
       }
    }
 
@@ -1380,7 +1381,7 @@ int ShapeGraphs::convertDataToAxial(Communicator *comm, const std::string& name,
    // add all visible layers to the set of polygon lines...
 
    std::map<int,Line> lines;
-   pmap<int,int> keys;
+   std::map<int,int> keys;
 
    //m_region = shapemap.getRegion();
    QtRegion region = shapemap.getRegion();
@@ -1393,13 +1394,13 @@ int ShapeGraphs::convertDataToAxial(Communicator *comm, const std::string& name,
       const SalaShape& poly = shape.second;
       if (poly.isLine()) {
          lines.insert(std::make_pair(count,poly.getLine()));
-         keys.add(count,key);
+         keys.insert(std::make_pair(count,key));
          count++;
       }
       else if (poly.isPolyLine()) {
          for (size_t j = 0; j < poly.size() - 1; j++) {
             lines.insert(std::make_pair(count,Line(poly[j],poly[j+1])));
-            keys.add(count,key);
+            keys.insert(std::make_pair(count,key));
             count++;
          }
       }
@@ -1445,7 +1446,7 @@ int ShapeGraphs::convertDataToAxial(Communicator *comm, const std::string& name,
          int j = -1;
          for (auto line: lines) {
             j++;
-            int inrow = input.getRowid(keys.search(line.first));
+            int inrow = input.getRowid(keys.find(line.first)->second);
             output.setValue(j,outcol,input.getValue(inrow,i));
          }
       }
@@ -1577,7 +1578,7 @@ int ShapeGraphs::convertDrawingToSegment(Communicator *comm, const std::string& 
    }
 
    std::map<int,Line> lines;  // pqmap for tidier, does not matter elsewhere...
-   pmap<int,int> layers;  // this is used to say which layer it originated from
+   std::map<int,int> layers;  // this is used to say which layer it originated from
    bool recordlayer = false;
 
    QtRegion region;
@@ -1599,18 +1600,18 @@ int ShapeGraphs::convertDrawingToSegment(Communicator *comm, const std::string& 
                 SalaShape& shape = refShape.second;
                if (shape.isLine()) {
                   lines.insert(std::make_pair(count,shape.getLine()));
-                  layers.add(count,j);
+                  layers.insert(std::make_pair(count,j));
                   count++;
                }
                else if (shape.isPolyLine() || shape.isPolygon()) {
                   for (size_t n = 0; n < shape.size() - 1; n++) {
                      lines.insert(std::make_pair(count,Line(shape[n],shape[n+1])));
-                     layers.add(count,j);
+                     layers.insert(std::make_pair(count,j));
                      count++;
                   }
                   if (shape.isPolygon()) { // add closing line
                      lines.insert(std::make_pair(count,Line(shape.tail(),shape.head())));
-                     layers.add(count,j);
+                     layers.insert(std::make_pair(count,j));
                      count++;
                   }
                }
@@ -1670,7 +1671,7 @@ int ShapeGraphs::convertDrawingToSegment(Communicator *comm, const std::string& 
       int k = -1;
       for (auto line: lines) {
          k++;
-         table.setValue(k,col,float(layers.search(line.first)));
+         table.setValue(k,col,float(layers.find(line.first)->second));
       }
    }
 
@@ -2786,14 +2787,14 @@ bool ShapeGraph::readold( istream& stream, int version )
    // read in from old base class
    SpacePixel linemap;
    linemap.read(stream, version);
-   const pmap<int,LineTest>& lines = linemap.getAllLines();
+   const std::map<int,LineTest>& lines = linemap.getAllLines();
 
    m_name = linemap.getName();
 
    // now copy to new base class:
    init(lines.size(),linemap.getRegion());
-   for (size_t i = 0; i < lines.size(); i++) {
-      makeLineShape(lines[i].line);
+   for (auto line: lines) {
+      makeLineShape(line.second.line);
    }
    // n.b., we now have to reclear attributes!
    m_attributes.clear();
@@ -3004,33 +3005,36 @@ void ShapeGraph::makeNewSegMap()
 {
    // now make a connection set from the ends of lines:
    prefvec<Connector> connectionset;
-   pmap<int,Line> lineset;
+   std::map<int,Line> lineset;
    for (auto shape: m_shapes) {
       if (shape.second.isLine()) {
          connectionset.push_back(Connector());
-         lineset.add(shape.first,shape.second.getLine());
+         lineset.insert(std::make_pair(shape.first,shape.second.getLine()));
       }
    }
 
    double maxdim = __max(m_region.width(),m_region.height());
 
-   for (size_t seg_a = 0; seg_a < lineset.size(); seg_a++) {
+   int seg_a = -1;
+   for (auto seg_a_line: lineset) {
+       seg_a++;
       // n.b., vector() is based on t_start and t_end, so we must use t_start and t_end here and throughout
-      PixelRef pix1 = pixelate(lineset[seg_a].t_start());
+      PixelRef pix1 = pixelate(seg_a_line.second.t_start());
       pqvector<ShapeRef> &shapes1 = m_pixel_shapes[pix1.x][pix1.y];
       for (size_t j1 = 0; j1 < shapes1.size(); j1++) {
-         size_t seg_b = lineset.searchindex(shapes1[j1].m_shape_ref);
-         if (seg_b != paftl::npos && seg_a < seg_b) {
-            Point2f alpha = lineset[seg_a].vector();
-            Point2f beta  = lineset[seg_b].vector();
+         auto seg_b_iter = lineset.find(shapes1[j1].m_shape_ref);
+         size_t seg_b = std::distance(lineset.begin(), seg_b_iter);
+         if (seg_b_iter != lineset.end() && seg_a < seg_b) {
+            Point2f alpha = seg_a_line.second.vector();
+            Point2f beta  = seg_b_iter->second.vector();
             alpha.normalise();
             beta.normalise();
-            if (approxeq(lineset[seg_a].t_start(),lineset[seg_b].t_start(),(maxdim*TOLERANCE_B))) {
+            if (approxeq(seg_a_line.second.t_start(),seg_b_iter->second.t_start(),(maxdim*TOLERANCE_B))) {
                float x = float(2.0 * acos(__min(__max(-dot(alpha,beta),-1.0),1.0)) / M_PI);
                connectionset[seg_a].m_back_segconns.add(SegmentRef(1,seg_b),x);
                connectionset[seg_b].m_back_segconns.add(SegmentRef(1,seg_a),x);
             }
-            if (approxeq(lineset[seg_a].t_start(),lineset[seg_b].t_end(),(maxdim*TOLERANCE_B))) {
+            if (approxeq(seg_a_line.second.t_start(),seg_b_iter->second.t_end(),(maxdim*TOLERANCE_B))) {
                float x = float(2.0 * acos(__min(__max(-dot(alpha,-beta),-1.0),1.0)) / M_PI);
                connectionset[seg_a].m_back_segconns.add(SegmentRef(-1,seg_b),x);
                connectionset[seg_b].m_forward_segconns.add(SegmentRef(1,seg_a),x);
@@ -3040,18 +3044,19 @@ void ShapeGraph::makeNewSegMap()
       PixelRef pix2 = pixelate(m_shapes.find(seg_a)->second.getLine().t_end());
       pqvector<ShapeRef> &shapes2 = m_pixel_shapes[pix2.x][pix2.y];
       for (size_t j2 = 0; j2 < shapes2.size(); j2++) {
-         size_t seg_b = lineset.searchindex(shapes2[j2].m_shape_ref);
-         if (seg_b != paftl::npos && seg_a < seg_b) {
-            Point2f alpha = lineset[seg_a].vector();
-            Point2f beta  = lineset[seg_b].vector();
+         auto seg_b_iter = lineset.find(shapes1[j2].m_shape_ref);
+         size_t seg_b = std::distance(lineset.begin(), seg_b_iter);
+         if (seg_b_iter != lineset.end() && seg_a < seg_b) {
+            Point2f alpha = seg_a_line.second.vector();
+            Point2f beta  = seg_b_iter->second.vector();
             alpha.normalise();
             beta.normalise();
-            if (approxeq(lineset[seg_a].t_end(),lineset[seg_b].t_start(),(maxdim*TOLERANCE_B))) {
+            if (approxeq(seg_a_line.second.t_end(),seg_b_iter->second.t_start(),(maxdim*TOLERANCE_B))) {
                float x = float(2.0 * acos(__min(__max(-dot(-alpha,beta),-1.0),1.0)) / M_PI);
                connectionset[seg_a].m_forward_segconns.add(SegmentRef(1,seg_b),x);
                connectionset[seg_b].m_back_segconns.add(SegmentRef(-1,seg_a),x);
             }
-            if (approxeq(lineset[seg_a].t_end(),lineset[seg_b].t_end(),(maxdim*TOLERANCE_B))) {
+            if (approxeq(seg_a_line.second.t_end(),seg_b_iter->second.t_end(),(maxdim*TOLERANCE_B))) {
                float x = float(2.0 * acos(__min(__max(-dot(-alpha,-beta),-1.0),1.0)) / M_PI);
                connectionset[seg_a].m_forward_segconns.add(SegmentRef(-1,seg_b),x);
                connectionset[seg_b].m_forward_segconns.add(SegmentRef(-1,seg_a),x);

--- a/salalib/axialmap.cpp
+++ b/salalib/axialmap.cpp
@@ -214,7 +214,7 @@ void AxialPolygons::init(prefvec<Line>& lines, const QtRegion& region)
    // need to init before making pixel polys...
    makePixelPolys();
    // now also add lines
-   for (auto vertexPoss: m_vertex_possibles) {
+   for (auto& vertexPoss: m_vertex_possibles) {
       for (size_t j = 0; j < vertexPoss.second.size(); j++) {
          addLine(Line(vertexPoss.first,vertexPoss.second.at(j)));
       }
@@ -322,7 +322,7 @@ void AxialPolygons::makePixelPolys()
    }
    // now register the vertices in each pixel...
    int j = -1;
-   for (auto vertPoss: m_vertex_possibles) {
+   for (auto& vertPoss: m_vertex_possibles) {
       j++;
       PixelRef pix = pixelate(vertPoss.first);
       m_pixel_polys[pix.x][pix.y].push_back(j);
@@ -404,7 +404,7 @@ void AxialPolygons::makeAxialLines(pqvector<AxialVertex>& openvertices, prefvec<
    m_handled_list.add(vertex);
 
    int i = -1;
-   for (auto vertPoss: m_vertex_possibles) {
+   for (auto& vertPoss: m_vertex_possibles) {
       i++;
       if (i == vertex.m_ref_key) {
          continue;
@@ -510,7 +510,7 @@ void AxialPolygons::makePolygons(prefvec<pqvector<Point2f>>& polygons)
    }
 
    int i = -1;
-   for (auto vertPoss: m_vertex_possibles) {
+   for (auto& vertPoss: m_vertex_possibles) {
       i++;
       if (vertPoss.second.size() == 1) {
          continue;
@@ -627,7 +627,7 @@ bool ShapeGraphs::makeAllLineMap(Communicator *comm, SuperSpacePixel& superspace
                region = runion(region,superspacepix.at(i).at(j).getRegion());
             }
             auto refShapes = superspacepix.at(i).at(j).getAllShapes();
-            for (auto refShape: refShapes) {
+            for (auto& refShape: refShapes) {
                 SalaShape& shape = refShape.second;
                if (shape.isLine()) {
                   lines.push_back(shape.getLine());
@@ -794,7 +794,7 @@ bool ShapeGraphs::makeFewestLineMap(Communicator *comm, bool replace_existing)
    // also, a list of radial lines cut by each axial line
    std::map<int,pvecint> ax_radial_cuts;
    std::map<int,pvecint> ax_seg_cuts;
-   for (auto shape: at(m_all_line_map).m_shapes) {
+   for (auto& shape: at(m_all_line_map).m_shapes) {
       ax_radial_cuts.insert(std::make_pair(shape.first, pvecint()));
       ax_seg_cuts.insert(std::make_pair(shape.first, pvecint()));
    }
@@ -979,7 +979,7 @@ void AxialMinimiser::removeSubsets(std::map<int,pvecint>& axsegcuts, std::map<Ra
       m_radialsegcounts[x] = 0;
    }
    int y = -1;
-   for (auto axSegCut: axsegcuts) {
+   for (auto& axSegCut: axsegcuts) {
       y++;
       for (size_t z = 0; z < axSegCut.second.size(); z++) {
          m_radialsegcounts[axSegCut.second[z]] += 1;
@@ -1272,7 +1272,7 @@ int ShapeGraphs::convertDrawingToAxial(Communicator *comm, const std::string& na
                region = runion(region,superspacepix.at(i).at(j).getRegion());
             }
             auto refShapes = superspacepix.at(i).at(j).getAllShapes();
-            for (auto refShape: refShapes) {
+            for (auto& refShape: refShapes) {
                 SalaShape& shape = refShape.second;
                if (shape.isLine()) {
                   lines.insert(std::make_pair(count,shape.getLine()));
@@ -1356,7 +1356,7 @@ int ShapeGraphs::convertDrawingToAxial(Communicator *comm, const std::string& na
       AttributeTable& table = usermap.getAttributeTable();
       int col = table.insertColumn("Drawing Layer");
       int k = -1;
-      for (auto line: lines) {
+      for (auto& line: lines) {
          k++;
          table.setValue(k,col,float(layers.find(line.first)->second));
       }
@@ -1389,7 +1389,7 @@ int ShapeGraphs::convertDataToAxial(Communicator *comm, const std::string& name,
    // add all visible layers to the set of polygon lines...
 
    int count = 0;
-   for (auto shape: shapemap.getAllShapes()) {
+   for (auto& shape: shapemap.getAllShapes()) {
       int key = shape.first;
       const SalaShape& poly = shape.second;
       if (poly.isLine()) {
@@ -1444,7 +1444,7 @@ int ShapeGraphs::convertDataToAxial(Communicator *comm, const std::string& name,
             colname = dXstring::formatString((int)k,input.getColumnName(i) + " %d");
          int outcol = output.insertColumn(colname);
          int j = -1;
-         for (auto line: lines) {
+         for (auto& line: lines) {
             j++;
             int inrow = input.getRowid(keys.find(line.first)->second);
             output.setValue(j,outcol,input.getValue(inrow,i));
@@ -1487,7 +1487,7 @@ int ShapeGraphs::convertDrawingToConvex(Communicator *comm, const std::string& n
       for (size_t j = 0; j < superspacepix.at(i).size(); j++) {
          if (superspacepix.at(i).at(j).isShown()) {
              auto refShapes = superspacepix.at(i).at(j).getAllShapes();
-             for (auto refShape: refShapes) {
+             for (auto& refShape: refShapes) {
                  SalaShape& shape = refShape.second;
                if (shape.isPolygon()) {
                   usermap.makeShape(shape);
@@ -1529,7 +1529,7 @@ int ShapeGraphs::convertDataToConvex(Communicator *comm, const std::string& name
    pvecint lookup;
    auto refShapes = shapemap.getAllShapes();
    int k = -1;
-   for (auto refShape: refShapes) {
+   for (auto& refShape: refShapes) {
       k++;
       SalaShape& shape = refShape.second;
       if (shape.isPolygon()) {
@@ -1596,7 +1596,7 @@ int ShapeGraphs::convertDrawingToSegment(Communicator *comm, const std::string& 
             }
 
             auto refShapes = superspacepix.at(i).at(j).getAllShapes();
-            for (auto refShape: refShapes) {
+            for (auto& refShape: refShapes) {
                 SalaShape& shape = refShape.second;
                if (shape.isLine()) {
                   lines.insert(std::make_pair(count,shape.getLine()));
@@ -1657,7 +1657,7 @@ int ShapeGraphs::convertDrawingToSegment(Communicator *comm, const std::string& 
 
    usermap.init(lines.size(),region);
 
-   for (auto line: lines) {
+   for (auto& line: lines) {
       usermap.makeLineShape(line.second);
    }
 
@@ -1669,7 +1669,7 @@ int ShapeGraphs::convertDrawingToSegment(Communicator *comm, const std::string& 
       AttributeTable& table = usermap.getAttributeTable();
       int col = table.insertColumn("Drawing Layer");
       int k = -1;
-      for (auto line: lines) {
+      for (auto& line: lines) {
          k++;
          table.setValue(k,col,float(layers.find(line.first)->second));
       }
@@ -1700,7 +1700,7 @@ int ShapeGraphs::convertDataToSegment(Communicator *comm, const std::string& nam
    // add all visible layers to the set of polygon lines...
 
    int count = 0;
-   for (auto shape: shapemap.getAllShapes()) {
+   for (auto& shape: shapemap.getAllShapes()) {
       int key = shape.first;
       const SalaShape& poly = shape.second;
       if (poly.isLine()) {
@@ -1746,7 +1746,7 @@ int ShapeGraphs::convertDataToSegment(Communicator *comm, const std::string& nam
    }
 
    usermap.init(lines.size(),region);
-   for (auto line: lines) {
+   for (auto& line: lines) {
       usermap.makeLineShape(line.second);
    }
 
@@ -1771,7 +1771,7 @@ int ShapeGraphs::convertDataToSegment(Communicator *comm, const std::string& nam
             colname = dXstring::formatString(k,input.getColumnName(i) + " %d");
          int outcol = output.insertColumn(colname);
          int j = -1;
-         for (auto line: lines) {
+         for (auto& line: lines) {
             j++;
             int inrow = input.getRowid(keys.search(line.first));
             output.setValue(j,outcol,input.getValue(inrow,i));
@@ -1963,7 +1963,7 @@ void ShapeGraph::makeConnections(const prefvec<pvecint>& keyvertices)
    int leng_col = m_attributes.insertLockedColumn("Line Length");
 
    int i = -1;
-   for (auto shape: m_shapes) {
+   for (auto& shape: m_shapes) {
       i++;
       int key = shape.first;
       int rowid = m_attributes.insertRow(key);
@@ -2012,7 +2012,7 @@ bool ShapeGraph::outputMifPolygons(ostream& miffile, ostream& midfile) const
 {
    // take lines from lines layer and make into regions (using the axial polygons)
    prefvec<Line> lines;
-   for (auto shape: m_shapes) {
+   for (auto& shape: m_shapes) {
       lines.push_back(shape.second.getLine());
    }
    AxialPolygons polygons;
@@ -2038,7 +2038,7 @@ void ShapeGraph::outputNet(ostream& netfile) const
    if (isSegmentMap()) {
       netfile << "*Vertices " << m_shapes.size() * 2 << endl;
       int i = -1;
-      for (auto shape: m_shapes) {
+      for (auto& shape: m_shapes) {
          i++;
          Line li = shape.second.getLine();
          Point2f p1 = li.start();
@@ -2074,7 +2074,7 @@ void ShapeGraph::outputNet(ostream& netfile) const
    else {
       netfile << "*Vertices " << m_shapes.size() << endl;
       int i = -1;
-      for (auto shape: m_shapes) {
+      for (auto& shape: m_shapes) {
          i++;
          Point2f p = shape.second.getCentroid();
          p.x = offset.x + (p.x - m_region.bottom_left.x) / maxdim;
@@ -2793,7 +2793,7 @@ bool ShapeGraph::readold( istream& stream, int version )
 
    // now copy to new base class:
    init(lines.size(),linemap.getRegion());
-   for (auto line: lines) {
+   for (auto& line: lines) {
       makeLineShape(line.second.line);
    }
    // n.b., we now have to reclear attributes!
@@ -2950,7 +2950,7 @@ void ShapeGraph::unlinkFromShapeMap(const ShapeMap& shapemap)
    // pair to unlink:
 
    const std::map<int,SalaShape>& polygons = shapemap.getAllShapes();
-   for (auto polygon: polygons) {
+   for (auto& polygon: polygons) {
       // just use the points:
       if (polygon.second.isPoint()) {
          pqvector<Point2f> closepoints;
@@ -3006,7 +3006,7 @@ void ShapeGraph::makeNewSegMap()
    // now make a connection set from the ends of lines:
    prefvec<Connector> connectionset;
    std::map<int,Line> lineset;
-   for (auto shape: m_shapes) {
+   for (auto& shape: m_shapes) {
       if (shape.second.isLine()) {
          connectionset.push_back(Connector());
          lineset.insert(std::make_pair(shape.first,shape.second.getLine()));
@@ -3016,7 +3016,7 @@ void ShapeGraph::makeNewSegMap()
    double maxdim = __max(m_region.width(),m_region.height());
 
    int seg_a = -1;
-   for (auto seg_a_line: lineset) {
+   for (auto& seg_a_line: lineset) {
        seg_a++;
       // n.b., vector() is based on t_start and t_end, so we must use t_start and t_end here and throughout
       PixelRef pix1 = pixelate(seg_a_line.second.t_start());
@@ -3244,7 +3244,7 @@ void ShapeGraph::initSegmentAttributes(prefvec<Connector>& connectionset)
    int leng_col = m_attributes.insertLockedColumn("Segment Length");
 
    int i = -1;
-   for (auto shape: m_shapes) {
+   for (auto& shape: m_shapes) {
        i++;
       int key = shape.first;
       int rowid = m_attributes.insertRow(key);
@@ -4282,7 +4282,7 @@ void TidyLines::quicktidy(std::map<int,Line>& lines, const QtRegion& region)
 
    double avglen = 0.0;
 
-   for (auto line: lines) {
+   for (auto& line: lines) {
       avglen += line.second.length();
    }
    avglen /= lines.size();
@@ -4300,7 +4300,7 @@ void TidyLines::quicktidy(std::map<int,Line>& lines, const QtRegion& region)
 
    // now load up m_lines...
    initLines(lines.size(),m_region.bottom_left,m_region.top_right);
-   for (auto line: lines) {
+   for (auto& line: lines) {
       addLine(line.second);
    }
    sortPixelLines();
@@ -4308,7 +4308,7 @@ void TidyLines::quicktidy(std::map<int,Line>& lines, const QtRegion& region)
    // and chop duplicate lines:
    std::vector<int> removelist;
    int i = -1;
-   for (auto line: lines) {
+   for (auto& line: lines) {
       i++;
       PixelRef start = pixelate(line.second.start());
       for (size_t j = 0; j < m_pixel_lines[start.x][start.y].size(); j++) {

--- a/salalib/axialmap.cpp
+++ b/salalib/axialmap.cpp
@@ -3044,7 +3044,7 @@ void ShapeGraph::makeNewSegMap()
       PixelRef pix2 = pixelate(m_shapes.find(seg_a)->second.getLine().t_end());
       pqvector<ShapeRef> &shapes2 = m_pixel_shapes[pix2.x][pix2.y];
       for (size_t j2 = 0; j2 < shapes2.size(); j2++) {
-         auto seg_b_iter = lineset.find(shapes1[j2].m_shape_ref);
+         auto seg_b_iter = lineset.find(shapes2[j2].m_shape_ref);
          size_t seg_b = std::distance(lineset.begin(), seg_b_iter);
          if (seg_b_iter != lineset.end() && seg_a < seg_b) {
             Point2f alpha = seg_a_line.second.vector();

--- a/salalib/axialmap.cpp
+++ b/salalib/axialmap.cpp
@@ -88,10 +88,11 @@ AxialPolygons::~AxialPolygons()
 
 AxialVertex AxialPolygons::makeVertex(const AxialVertexKey& vertexkey, const Point2f& openspace)
 {
-   AxialVertex av(vertexkey, m_vertex_possibles.key(vertexkey.m_ref_key), openspace);
+   auto vertPossIter = depthmapX::getMapAtIndex(m_vertex_possibles, vertexkey.m_ref_key);
+   AxialVertex av(vertexkey, vertPossIter->first, openspace);
 
    // n.b., at this point, vertex key m_a and m_b are unfixed
-   pqvector<Point2f>& pointlist = m_vertex_possibles.value(vertexkey.m_ref_key);
+   pqvector<Point2f>& pointlist = vertPossIter->second;
    if (pointlist.size() < 2) {
       return av;
    }
@@ -212,9 +213,9 @@ void AxialPolygons::init(prefvec<Line>& lines, const QtRegion& region)
    // need to init before making pixel polys...
    makePixelPolys();
    // now also add lines
-   for (i = 0; i < m_vertex_possibles.size(); i++) {
-      for (size_t j = 0; j < m_vertex_possibles.value(i).size(); j++) {
-         addLine(Line(m_vertex_possibles.key(i),m_vertex_possibles.value(i).at(j)));
+   for (auto vertexPoss: m_vertex_possibles) {
+      for (size_t j = 0; j < vertexPoss.second.size(); j++) {
+         addLine(Line(vertexPoss.first,vertexPoss.second.at(j)));
       }
    }
    sortPixelLines();
@@ -240,7 +241,7 @@ void AxialPolygons::makeVertexPossibles(const prefvec<Line>& lines, const prefve
    for (i = 0; i < lines.size(); i++) {
       if (found[0][i] == -1) {
          pointlookup.push_back(lines[i].start());
-         m_vertex_possibles.add(pointlookup.tail(),pqvector<Point2f>());
+         m_vertex_possibles.insert(std::make_pair(pointlookup.tail(),pqvector<Point2f>()));
          m_vertex_polys.push_back(-1); // <- n.b., dummy entry for now, maintain with vertex possibles
          found[0][i] = pointlookup.size() - 1;
          for (size_t j = 0; j < connectionset[i].m_back_segconns.size(); j++) {
@@ -251,7 +252,7 @@ void AxialPolygons::makeVertexPossibles(const prefvec<Line>& lines, const prefve
       }
       if (found[1][i] == -1) {
          pointlookup.push_back(lines[i].end());
-         m_vertex_possibles.add(pointlookup.tail(),pqvector<Point2f>());
+         m_vertex_possibles.insert(std::make_pair(pointlookup.tail(),pqvector<Point2f>()));
          m_vertex_polys.push_back(-1); // <- n.b., dummy entry for now, maintain with vertex possibles
          found[1][i] = pointlookup.size() - 1;
          for (size_t j = 0; j < connectionset[i].m_forward_segconns.size(); j++) {
@@ -266,13 +267,13 @@ void AxialPolygons::makeVertexPossibles(const prefvec<Line>& lines, const prefve
       if (found[0][i] == -1 || found[1][i] == -1) {
          throw 1;
       }
-      size_t index0 = m_vertex_possibles.searchindex(pointlookup.at(found[0][i]));
-      size_t index1 = m_vertex_possibles.searchindex(pointlookup.at(found[1][i]));
-      if (index0 == paftl::npos || index1 == paftl::npos) {
+      auto index0 = m_vertex_possibles.find(pointlookup.at(found[0][i]));
+      auto index1 = m_vertex_possibles.find(pointlookup.at(found[1][i]));
+      if (index0 == m_vertex_possibles.end() || index1 == m_vertex_possibles.end()) {
          throw 2;
       }
-      m_vertex_possibles.value(index0).add(pointlookup.at(found[1][i]));
-      m_vertex_possibles.value(index1).add(pointlookup.at(found[0][i]));
+      index0->second.add(pointlookup.at(found[1][i]));
+      index1->second.add(pointlookup.at(found[0][i]));
    }
    delete [] found[0];
    delete [] found[1];
@@ -285,11 +286,11 @@ void AxialPolygons::makeVertexPossibles(const prefvec<Line>& lines, const prefve
          addlist.push_back(i);
          while (addlist.size()) {
             m_vertex_polys[addlist.tail()] = current_poly;
-            pqvector<Point2f>& connections = m_vertex_possibles.value(addlist.tail());
+            pqvector<Point2f>& connections = depthmapX::getMapAtIndex(m_vertex_possibles, addlist.tail())->second;
             addlist.pop_back();
             for (size_t j = 0; j < connections.size(); j++) {
-               size_t index = m_vertex_possibles.searchindex(connections[j]);
-               if (index == paftl::npos) {
+               int index = depthmapX::findIndexFromKey(m_vertex_possibles, connections[j]);
+               if (index == -1) {
                   throw 3;
                }
                if (m_vertex_polys[index] == -1) {
@@ -319,8 +320,10 @@ void AxialPolygons::makePixelPolys()
       m_pixel_polys[i] = new pvecint[m_rows];
    }
    // now register the vertices in each pixel...
-   for (size_t j = 0; j < m_vertex_possibles.size(); j++) {
-      PixelRef pix = pixelate(m_vertex_possibles.key(j));
+   int j = -1;
+   for (auto vertPoss: m_vertex_possibles) {
+      j++;
+      PixelRef pix = pixelate(vertPoss.first);
       m_pixel_polys[pix.x][pix.y].push_back(j);
    }
 }
@@ -343,7 +346,7 @@ AxialVertexKey AxialPolygons::seedVertex(const Point2f& seed)
    while (!foundvertex) {
       for (size_t i = 0; i < m_pixel_polys[seedref.x][seedref.y].size(); i++) {
          int vertexref = m_pixel_polys[seedref.x][seedref.y][i];
-         const Point2f& trialpoint = m_vertex_possibles.key(vertexref);
+         const Point2f& trialpoint = depthmapX::getMapAtIndex(m_vertex_possibles, vertexref)->first;
          if (!intersect_exclude(Line(seed,trialpoint))) {
             // yay... ...but wait... we need to see if it's a proper polygon vertex first...
             seedvertex = vertexref;
@@ -399,12 +402,14 @@ void AxialPolygons::makeAxialLines(pqvector<AxialVertex>& openvertices, prefvec<
 
    m_handled_list.add(vertex);
 
-   for (size_t i = 0; i < m_vertex_possibles.size(); i++) {
+   int i = -1;
+   for (auto vertPoss: m_vertex_possibles) {
+      i++;
       if (i == vertex.m_ref_key) {
          continue;
       }
       bool possible = false, stubpossible = false;
-      Point2f p = m_vertex_possibles.key(i) - vertex.m_point;
+      Point2f p = vertPoss.first - vertex.m_point;
       if (vertex.m_convex) {
          if (det(vertex.m_a,p) > 0 && det(vertex.m_b,p) > 0) {
             possible = true;
@@ -420,7 +425,7 @@ void AxialPolygons::makeAxialLines(pqvector<AxialVertex>& openvertices, prefvec<
          }
       }
       if (possible || stubpossible) {
-         Line line(m_vertex_possibles.key(i),vertex.m_point);
+         Line line(vertPoss.first,vertex.m_point);
          if (!intersect_exclude(line)) {
             AxialVertex next_vertex = makeVertex(AxialVertexKey(i),vertex.m_point);
             if (next_vertex.m_initialised && m_handled_list.searchindex(next_vertex) == paftl::npos) {
@@ -443,7 +448,7 @@ void AxialPolygons::makeAxialLines(pqvector<AxialVertex>& openvertices, prefvec<
                   poly_connections.push_back( PolyConnector(shortline, (RadialKey)radialshort) );
                   radial_lines.add(radialshort);
                   if (!vertex.m_convex && possible) {
-                     Line longline = Line(m_vertex_possibles.key(i),line.t_end());
+                     Line longline = Line(vertPoss.first,line.t_end());
                      RadialLine radiallong(radialshort);
                      radiallong.segend = shortline_segend ? 0 : 1;
                      poly_connections.push_back( PolyConnector(longline, (RadialKey)radiallong) );
@@ -503,34 +508,36 @@ void AxialPolygons::makePolygons(prefvec<pqvector<Point2f>>& polygons)
       handled_list.push_back(pvecint());
    }
 
-   for (size_t i = 0; i < m_vertex_possibles.size(); i++) {
-      if (m_vertex_possibles.value(i).size() == 1) {
+   int i = -1;
+   for (auto vertPoss: m_vertex_possibles) {
+      i++;
+      if (vertPoss.second.size() == 1) {
          continue;
       }
-      for (size_t j = 0; j < m_vertex_possibles.value(i).size(); j++) {
+      for (size_t j = 0; j < vertPoss.second.size(); j++) {
          if (handled_list[i].findindex(j) != paftl::npos) {
             continue;
          }
          handled_list[i].push_back(j);
-         Point2f& key = m_vertex_possibles.key(i);
+         const Point2f& key = vertPoss.first;
          pqvector<Point2f> polygon;
          polygon.push_back(key);
-         Point2f curr = m_vertex_possibles.value(i).at(j);
+         Point2f curr = vertPoss.second.at(j);
          Point2f last = key;
          bool good = true;
          while (curr != key) {
-            size_t n = m_vertex_possibles.searchindex(curr);
+            auto vertPossIter = m_vertex_possibles.find(curr);
             polygon.push_back(curr);
             // hunt down left most
             int winner = -1, wayback = -1;
             double minangle = 2 * M_PI;
-            for (size_t k = 0; k < m_vertex_possibles.value(n).size(); k++) {
-               Point2f next = m_vertex_possibles.value(n).at(k);
+            for (size_t k = 0; k < vertPossIter->second.size(); k++) {
+               Point2f next = vertPossIter->second.at(k);
                if (last != next) {
                   double thisangle = angle(last,curr,next);
                   if (thisangle < minangle) {
                      // check not going to a dead end:
-                     if (m_vertex_possibles.search(m_vertex_possibles.value(n).at(k)).size() > 1) {
+                     if (m_vertex_possibles.find(vertPossIter->second.at(k))->second.size() > 1) {
                         minangle = thisangle;
                         winner = k;
                      }
@@ -544,9 +551,9 @@ void AxialPolygons::makePolygons(prefvec<pqvector<Point2f>>& polygons)
                // this happens when you follow a false trail -- go back the way you came!
                winner = wayback;
             }
-            handled_list[n].push_back(winner);
+            handled_list[std::distance(m_vertex_possibles.begin(), vertPossIter)].push_back(winner);
             last = curr;
-            curr = m_vertex_possibles.value(n).at(winner);
+            curr = vertPossIter->second.at(winner);
          }
          if (good) {
             polygons.push_back(polygon);
@@ -777,18 +784,18 @@ bool ShapeGraphs::makeFewestLineMap(Communicator *comm, bool replace_existing)
    pafsrand((unsigned int)time(NULL));
 
    // make one rld for each radial line...
-   pqmap<RadialKey,pvecint> radialdivisions;
+   std::map<RadialKey,pvecint> radialdivisions;
    size_t i;
    for (i = 0; i < m_radial_lines.size(); i++) {
-      radialdivisions.add( (RadialKey) m_radial_lines[i], pvecint() );
+      radialdivisions.insert(std::make_pair( (RadialKey) m_radial_lines[i], pvecint() ));
    }
 
    // also, a list of radial lines cut by each axial line
-   pqmap<int,pvecint> ax_radial_cuts;
-   pqmap<int,pvecint> ax_seg_cuts;
+   std::map<int,pvecint> ax_radial_cuts;
+   std::map<int,pvecint> ax_seg_cuts;
    for (auto shape: at(m_all_line_map).m_shapes) {
-      ax_radial_cuts.add(shape.first, pvecint());
-      ax_seg_cuts.add(shape.first, pvecint());
+      ax_radial_cuts.insert(std::make_pair(shape.first, pvecint()));
+      ax_seg_cuts.insert(std::make_pair(shape.first, pvecint()));
    }
 
    // make divisions -- this is the slow part and the comm updates
@@ -801,7 +808,7 @@ bool ShapeGraphs::makeFewestLineMap(Communicator *comm, bool replace_existing)
    }
 
    // a little further setting up is still required...
-   pqmap<RadialKey,RadialSegment> radialsegs;
+   std::map<RadialKey,RadialSegment> radialsegs;
 
    // now make radial segments from the radial lines... (note, start at 1)
    for (i = 1; i < m_radial_lines.size(); i++) {
@@ -812,9 +819,9 @@ bool ShapeGraphs::makeFewestLineMap(Communicator *comm, bool replace_existing)
          else {
             // Quick mod - TV
 #if defined(_WIN32)
-            radialsegs.add( (RadialKey)m_radial_lines[i], (RadialKey)m_radial_lines[i-1]);
+            radialsegs.insert(std::make_pair( (RadialKey)m_radial_lines[i], (RadialKey)m_radial_lines[i-1]));
 #else
-            radialsegs.add( (RadialKey)m_radial_lines[i], (RadialSegment)m_radial_lines[i-1]);
+            radialsegs.insert(std::make_pair( (RadialKey)m_radial_lines[i], (RadialSegment)m_radial_lines[i-1]));
 #endif
          }
       }
@@ -822,15 +829,18 @@ bool ShapeGraphs::makeFewestLineMap(Communicator *comm, bool replace_existing)
 
    // and segment divisors from the axial lines...
    for (i = 0; i < at(m_all_line_map).m_shapes.size(); i++) {
-      for (size_t j = 1; j < ax_radial_cuts[i].size(); j++) {
+      auto axIter = depthmapX::getMapAtIndex(ax_radial_cuts, i);
+      auto axSeg = depthmapX::getMapAtIndex(ax_seg_cuts, i)->second;
+      for (size_t j = 1; j < axIter->second.size(); j++) {
          // note similarity to loop above
-         RadialKey rk_end = m_radial_lines[ax_radial_cuts[i][j]];
-         RadialKey rk_start = m_radial_lines[ax_radial_cuts[i][j-1]];
+         RadialKey rk_end = m_radial_lines[axIter->second[j]];
+         RadialKey rk_start = m_radial_lines[axIter->second[j-1]];
          if (rk_start.vertex == rk_end.vertex) {
-            size_t index = radialsegs.searchindex(rk_end);
-            if (index != paftl::npos && rk_start == radialsegs[index].radial_b) {
-               radialsegs[index].add(ax_radial_cuts.key(i));
-               ax_seg_cuts[i].add(index);
+            auto radialSegIter = radialsegs.find(rk_end);
+            size_t index = std::distance(radialsegs.begin(), radialSegIter);
+            if (radialSegIter != radialsegs.end() && rk_start == radialSegIter->second.radial_b) {
+               radialSegIter->second.add(axIter->first);
+               axSeg.add(index);
             }
          }
       }
@@ -936,7 +946,7 @@ bool ShapeGraphs::makeFewestLineMap(Communicator *comm, bool replace_existing)
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-AxialMinimiser::AxialMinimiser(const ShapeGraph& alllinemap, pqmap<int,pvecint>& axsegcuts, pqmap<RadialKey,RadialSegment>& radialsegs)
+AxialMinimiser::AxialMinimiser(const ShapeGraph& alllinemap, std::map<int, pvecint> &axsegcuts, std::map<RadialKey, RadialSegment> &radialsegs)
 {
    m_alllinemap = (ShapeGraph *) &alllinemap;
 
@@ -958,7 +968,7 @@ AxialMinimiser::~AxialMinimiser()
 
 // Alan and Bill's algo...
 
-void AxialMinimiser::removeSubsets(pqmap<int,pvecint>& axsegcuts, pqmap<RadialKey,RadialSegment>& radialsegs, pqmap<RadialKey,pvecint>& rlds,  pqvector<RadialLine>& radial_lines, prefvec<pvecint>& keyvertexconns, int *keyvertexcounts)
+void AxialMinimiser::removeSubsets(std::map<int,pvecint>& axsegcuts, std::map<RadialKey,RadialSegment>& radialsegs, std::map<RadialKey,pvecint>& rlds,  pqvector<RadialLine>& radial_lines, prefvec<pvecint>& keyvertexconns, int *keyvertexcounts)
 {
    bool removedflag = true;
    int counterrors = 0;
@@ -968,9 +978,11 @@ void AxialMinimiser::removeSubsets(pqmap<int,pvecint>& axsegcuts, pqmap<RadialKe
    for (size_t x = 0; x < radialsegs.size(); x++) {
       m_radialsegcounts[x] = 0;
    }
-   for (size_t y = 0; y < axsegcuts.size(); y++) {
-      for (size_t z = 0; z < axsegcuts[y].size(); z++) {
-         m_radialsegcounts[axsegcuts[y][z]] += 1;
+   int y = -1;
+   for (auto axSegCut: axsegcuts) {
+      y++;
+      for (size_t z = 0; z < axSegCut.second.size(); z++) {
+         m_radialsegcounts[axSegCut.second[z]] += 1;
       }
       m_removed[y] = false;
       m_vital[y] = false;
@@ -1054,14 +1066,15 @@ void AxialMinimiser::removeSubsets(pqmap<int,pvecint>& axsegcuts, pqmap<RadialKe
             size_t removeindex = ii;
             // now check removing it won't break any topological loops
             bool presumedvital = false;
-            for (size_t k = 0; k < axsegcuts[removeindex].size(); k++) {
-               if (m_radialsegcounts[axsegcuts[removeindex][k]] <= 1) {
+            auto axSegCut = depthmapX::getMapAtIndex(axsegcuts, removeindex)->second;
+            for (size_t k = 0; k < axSegCut.size(); k++) {
+               if (m_radialsegcounts[axSegCut[k]] <= 1) {
                   presumedvital = true;
                   break;
                }
             }
             if (presumedvital) {
-               presumedvital = checkVital(removeindex,axsegcuts[removeindex],radialsegs,rlds,radial_lines);
+               presumedvital = checkVital(removeindex,axSegCut,radialsegs,rlds,radial_lines);
             }
             if (presumedvital) {
                m_vital[removeindex] = true;
@@ -1082,8 +1095,8 @@ void AxialMinimiser::removeSubsets(pqmap<int,pvecint>& axsegcuts, pqmap<RadialKe
                   }
                }
                removedflag = true;
-               for (k = 0; k < axsegcuts[removeindex].size(); k++) {
-                  m_radialsegcounts[axsegcuts[removeindex][k]] -= 1;
+               for (k = 0; k < axSegCut.size(); k++) {
+                  m_radialsegcounts[axSegCut[k]] -= 1;
                }
                // vital connections
                for (k = 0; k < keyvertexconns[removeindex].size(); k++) {
@@ -1099,7 +1112,7 @@ void AxialMinimiser::removeSubsets(pqmap<int,pvecint>& axsegcuts, pqmap<RadialKe
 
 // My algo... v. simple... fewest longest
 
-void AxialMinimiser::fewestLongest(pqmap<int,pvecint>& axsegcuts, pqmap<RadialKey,RadialSegment>& radialsegs, pqmap<RadialKey,pvecint>& rlds, pqvector<RadialLine>& radial_lines, prefvec<pvecint>& keyvertexconns, int *keyvertexcounts)
+void AxialMinimiser::fewestLongest(std::map<int,pvecint>& axsegcuts, std::map<RadialKey,RadialSegment>& radialsegs, std::map<RadialKey, pvecint> &rlds, pqvector<RadialLine>& radial_lines, prefvec<pvecint>& keyvertexconns, int *keyvertexcounts)
 {
    //m_axialconns = m_alllinemap->m_connectors;
    int livecount = 0;
@@ -1134,14 +1147,15 @@ void AxialMinimiser::fewestLongest(pqmap<int,pvecint>& axsegcuts, pqmap<RadialKe
       }
       //
       bool presumedvital = false;
-      for (k = 0; k < axsegcuts[j].size(); k++) {
-         if (m_radialsegcounts[axsegcuts[j][k]] <= 1) {
+      auto axSegCut = depthmapX::getMapAtIndex(axsegcuts, j)->second;
+      for (k = 0; k < axSegCut.size(); k++) {
+         if (m_radialsegcounts[axSegCut[k]] <= 1) {
             presumedvital = true;
             break;
          }
       }
       if (presumedvital) {
-         presumedvital = checkVital(j,axsegcuts[j],radialsegs,rlds,radial_lines);
+         presumedvital = checkVital(j,axSegCut,radialsegs,rlds,radial_lines);
       }
       if (!presumedvital) {
          // don't let anything this is connected to go down to zero connections
@@ -1170,8 +1184,8 @@ void AxialMinimiser::fewestLongest(pqmap<int,pvecint>& axsegcuts, pqmap<RadialKe
                m_affected[affectedconnections[k]] = true;
             }
          }
-         for (k = 0; k < axsegcuts[j].size(); k++) {
-            m_radialsegcounts[axsegcuts[j][k]] -= 1;
+         for (k = 0; k < axSegCut.size(); k++) {
+            m_radialsegcounts[axSegCut[k]] -= 1;
          }
          // vital connections
          for (k = 0; k < keyvertexconns[j].size(); k++) {
@@ -1183,7 +1197,7 @@ void AxialMinimiser::fewestLongest(pqmap<int,pvecint>& axsegcuts, pqmap<RadialKe
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-bool AxialMinimiser::checkVital(int checkindex, pvecint& axsegcuts, pqmap<RadialKey,RadialSegment>& radialsegs, pqmap<RadialKey,pvecint>& rlds, pqvector<RadialLine>& radial_lines)
+bool AxialMinimiser::checkVital(int checkindex, pvecint& axsegcuts, std::map<RadialKey,RadialSegment>& radialsegs, std::map<RadialKey, pvecint> &rlds, pqvector<RadialLine>& radial_lines)
 {
    std::map<int,SalaShape>& axiallines = m_alllinemap->m_shapes;
 
@@ -1194,10 +1208,11 @@ bool AxialMinimiser::checkVital(int checkindex, pvecint& axsegcuts, pqmap<Radial
       if (m_radialsegcounts[axsegcuts[k]] <= 1) {
          bool nonvitalseg = false;
          vitalsegs++;
-         RadialKey& key = radialsegs.key(axsegcuts[k]);
-         RadialSegment& seg = radialsegs.value(axsegcuts[k]);
-         pvecint& divisorsa = rlds.search(key);
-         pvecint& divisorsb = rlds.search(seg.radial_b);
+         auto radialSegIter = depthmapX::getMapAtIndex(radialsegs, axsegcuts[k]);
+         const RadialKey& key = radialSegIter->first;
+         RadialSegment& seg = radialSegIter->second;
+         pvecint& divisorsa = rlds.find(key)->second;
+         pvecint& divisorsb = rlds.find(seg.radial_b)->second;
          RadialLine& rlinea = radial_lines.search(key);
          RadialLine& rlineb = radial_lines.search(seg.radial_b);
          for (size_t divi = 0; divi < divisorsa.size(); divi++) {
@@ -1240,7 +1255,7 @@ int ShapeGraphs::convertDrawingToAxial(Communicator *comm, const std::string& na
    }
 
    QtRegion region;
-   pqmap<int,Line> lines;  // map required for tidy lines, otherwise acts like vector
+   std::map<int,Line> lines;  // map required for tidy lines, otherwise acts like vector
    pmap<int,int> layers;  // this is used to say which layer it originated from
 
    bool recordlayer = false;
@@ -1260,18 +1275,18 @@ int ShapeGraphs::convertDrawingToAxial(Communicator *comm, const std::string& na
             for (auto refShape: refShapes) {
                 SalaShape& shape = refShape.second;
                if (shape.isLine()) {
-                  lines.add(count,shape.getLine());
+                  lines.insert(std::make_pair(count,shape.getLine()));
                   layers.add(count,j);
                   count++;
                }
                else if (shape.isPolyLine() || shape.isPolygon()) {
                   for (size_t n = 0; n < shape.size() - 1; n++) {
-                     lines.add(count,Line(shape[n],shape[n+1]));
+                     lines.insert(std::make_pair(count,Line(shape[n],shape[n+1])));
                      layers.add(count,j);
                      count++;
                   }
                   if (shape.isPolygon()) {
-                     lines.add(count,Line(shape.tail(),shape.head()));
+                     lines.insert(std::make_pair(count,Line(shape.tail(),shape.head())));
                      layers.add(count,j);
                      count++;
                   }
@@ -1340,8 +1355,10 @@ int ShapeGraphs::convertDrawingToAxial(Communicator *comm, const std::string& na
    if (recordlayer) {
       AttributeTable& table = usermap.getAttributeTable();
       int col = table.insertColumn("Drawing Layer");
-      for (size_t k = 0; k < lines.size(); k++) {
-         table.setValue(k,col,float(layers.search(lines.key(k))));
+      int k = -1;
+      for (auto line: lines) {
+         k++;
+         table.setValue(k,col,float(layers.search(line.first)));
       }
    }
 
@@ -1363,7 +1380,7 @@ int ShapeGraphs::convertDataToAxial(Communicator *comm, const std::string& name,
 
    // add all visible layers to the set of polygon lines...
 
-   pqmap<int,Line> lines;
+   std::map<int,Line> lines;
    pmap<int,int> keys;
 
    //m_region = shapemap.getRegion();
@@ -1376,13 +1393,13 @@ int ShapeGraphs::convertDataToAxial(Communicator *comm, const std::string& name,
       int key = shape.first;
       const SalaShape& poly = shape.second;
       if (poly.isLine()) {
-         lines.add(count,poly.getLine());
+         lines.insert(std::make_pair(count,poly.getLine()));
          keys.add(count,key);
          count++;
       }
       else if (poly.isPolyLine()) {
          for (size_t j = 0; j < poly.size() - 1; j++) {
-            lines.add(count,Line(poly[j],poly[j+1]));
+            lines.insert(std::make_pair(count,Line(poly[j],poly[j+1])));
             keys.add(count,key);
             count++;
          }
@@ -1426,8 +1443,10 @@ int ShapeGraphs::convertDataToAxial(Communicator *comm, const std::string& name,
          for (size_t k = 1; output.getColumnIndex(colname) != -1; k++) 
             colname = dXstring::formatString((int)k,input.getColumnName(i) + " %d");
          int outcol = output.insertColumn(colname);
-         for (size_t j = 0; j < lines.size(); j++) {
-            int inrow = input.getRowid(keys.search(lines.key(j)));
+         int j = -1;
+         for (auto line: lines) {
+            j++;
+            int inrow = input.getRowid(keys.search(line.first));
             output.setValue(j,outcol,input.getValue(inrow,i));
          }
       }
@@ -1558,7 +1577,7 @@ int ShapeGraphs::convertDrawingToSegment(Communicator *comm, const std::string& 
       comm->CommPostMessage( Communicator::CURRENT_STEP, 1 );
    }
 
-   pqmap<int,Line> lines;  // pqmap for tidier, does not matter elsewhere...
+   std::map<int,Line> lines;  // pqmap for tidier, does not matter elsewhere...
    pmap<int,int> layers;  // this is used to say which layer it originated from
    bool recordlayer = false;
 
@@ -1580,18 +1599,18 @@ int ShapeGraphs::convertDrawingToSegment(Communicator *comm, const std::string& 
             for (auto refShape: refShapes) {
                 SalaShape& shape = refShape.second;
                if (shape.isLine()) {
-                  lines.add(count,shape.getLine());
+                  lines.insert(std::make_pair(count,shape.getLine()));
                   layers.add(count,j);
                   count++;
                }
                else if (shape.isPolyLine() || shape.isPolygon()) {
                   for (size_t n = 0; n < shape.size() - 1; n++) {
-                     lines.add(count,Line(shape[n],shape[n+1]));
+                     lines.insert(std::make_pair(count,Line(shape[n],shape[n+1])));
                      layers.add(count,j);
                      count++;
                   }
                   if (shape.isPolygon()) { // add closing line
-                     lines.add(count,Line(shape.tail(),shape.head()));
+                     lines.insert(std::make_pair(count,Line(shape.tail(),shape.head())));
                      layers.add(count,j);
                      count++;
                   }
@@ -1638,8 +1657,8 @@ int ShapeGraphs::convertDrawingToSegment(Communicator *comm, const std::string& 
 
    usermap.init(lines.size(),region);
 
-   for (size_t k = 0; k < lines.size(); k++) {
-      usermap.makeLineShape(lines[k]);
+   for (auto line: lines) {
+      usermap.makeLineShape(line.second);
    }
 
    // make it!
@@ -1649,8 +1668,10 @@ int ShapeGraphs::convertDrawingToSegment(Communicator *comm, const std::string& 
    if (recordlayer) {
       AttributeTable& table = usermap.getAttributeTable();
       int col = table.insertColumn("Drawing Layer");
-      for (size_t k = 0; k < lines.size(); k++) {
-         table.setValue(k,col,float(layers.search(lines.key(k))));
+      int k = -1;
+      for (auto line: lines) {
+         k++;
+         table.setValue(k,col,float(layers.search(line.first)));
       }
    }
 
@@ -1669,7 +1690,7 @@ int ShapeGraphs::convertDataToSegment(Communicator *comm, const std::string& nam
       comm->CommPostMessage( Communicator::CURRENT_STEP, 1 );
    }
 
-   pqmap<int,Line> lines;
+   std::map<int,Line> lines;
    pmap<int,int> keys;
 
    // no longer requires m_region
@@ -1683,13 +1704,13 @@ int ShapeGraphs::convertDataToSegment(Communicator *comm, const std::string& nam
       int key = shape.first;
       const SalaShape& poly = shape.second;
       if (poly.isLine()) {
-         lines.add(count,poly.getLine());
+         lines.insert(std::make_pair(count,poly.getLine()));
          keys.add(count,key);
          count++;
       }
       else if (poly.isPolyLine()) {
          for (size_t j = 0; j < poly.size() - 1; j++) {
-            lines.add(count,Line(poly[j],poly[j+1]));
+            lines.insert(std::make_pair(count,Line(poly[j],poly[j+1])));
             keys.add(count,key);
             count++;
          }
@@ -1725,8 +1746,8 @@ int ShapeGraphs::convertDataToSegment(Communicator *comm, const std::string& nam
    }
 
    usermap.init(lines.size(),region);
-   for (size_t k = 0; k < lines.size(); k++) {
-      usermap.makeLineShape(lines[k]);
+   for (auto line: lines) {
+      usermap.makeLineShape(line.second);
    }
 
    // start to be a little bit more efficient about memory now we are hitting the limits
@@ -1749,8 +1770,10 @@ int ShapeGraphs::convertDataToSegment(Communicator *comm, const std::string& nam
          for (int k = 1; output.getColumnIndex(colname) != -1; k++) 
             colname = dXstring::formatString(k,input.getColumnName(i) + " %d");
          int outcol = output.insertColumn(colname);
-         for (size_t j = 0; j < lines.size(); j++) {
-            int inrow = input.getRowid(keys.search(lines.key(j)));
+         int j = -1;
+         for (auto line: lines) {
+            j++;
+            int inrow = input.getRowid(keys.search(line.first));
             output.setValue(j,outcol,input.getValue(inrow,i));
          }
       }
@@ -2073,7 +2096,7 @@ void ShapeGraph::outputNet(ostream& netfile) const
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-void ShapeGraph::makeDivisions(const prefvec<PolyConnector>& polyconnections, const pqvector<RadialLine>& radiallines, pqmap<RadialKey,pvecint>& radialdivisions, pqmap<int,pvecint>& axialdividers, Communicator *comm)
+void ShapeGraph::makeDivisions(const prefvec<PolyConnector>& polyconnections, const pqvector<RadialLine>& radiallines, std::map<RadialKey,pvecint>& radialdivisions, std::map<int, pvecint> &axialdividers, Communicator *comm)
 {
     // Quick mod - TV
 #if defined(_WIN32)
@@ -2089,7 +2112,8 @@ void ShapeGraph::makeDivisions(const prefvec<PolyConnector>& polyconnections, co
    for (size_t i = 0; i < polyconnections.size(); i++) {
       PixelRefVector pixels = pixelateLine(polyconnections[i].line);
       pvecint testedshapes;
-      size_t connindex = radialdivisions.searchindex(polyconnections[i].key);
+      auto connIter = radialdivisions.find(polyconnections[i].key);
+      size_t connindex = std::distance(radialdivisions.begin(), connIter);
       double tolerance = sqrt(TOLERANCE_A);// * polyconnections[i].line.length();
       for (size_t j = 0; j < pixels.size(); j++) {
          PixelRef pix = pixels[j];
@@ -2108,17 +2132,17 @@ void ShapeGraph::makeDivisions(const prefvec<PolyConnector>& polyconnections, co
                   break;
                case 2:
                   {
-                     size_t index = axialdividers.searchindex(shape.m_shape_ref);
+                     size_t index = depthmapX::findIndexFromKey(axialdividers, (int) shape.m_shape_ref);
                      if (int(index) != shape.m_shape_ref) {
                         throw 1; // for the code to work later this can't be true!
                      }
                      axialdividers[index].add(connindex);
-                     radialdivisions[connindex].add(shape.m_shape_ref);
+                     connIter->second.add(shape.m_shape_ref);
                   }
                   break;
                case 1:
                   {
-                     size_t index = axialdividers.searchindex(shape.m_shape_ref);
+                     size_t index = depthmapX::findIndexFromKey(axialdividers, (int) shape.m_shape_ref);
                      if (int(index) != shape.m_shape_ref) {
                         throw 1; // for the code to work later this can't be true!
                      }
@@ -2126,7 +2150,7 @@ void ShapeGraph::makeDivisions(const prefvec<PolyConnector>& polyconnections, co
                      // this makes sure actually crosses between the line and the openspace properly
                      if (radiallines[connindex].cuts(line)) {
                         axialdividers[index].add(connindex);
-                        radialdivisions[connindex].add(shape.m_shape_ref);
+                        connIter->second.add(shape.m_shape_ref);
                      }
                   }
                   break;
@@ -2143,32 +2167,6 @@ void ShapeGraph::makeDivisions(const prefvec<PolyConnector>& polyconnections, co
             }
             comm->CommPostMessage( Communicator::CURRENT_RECORD, i );
          }         
-      }
-   }
-}
-
-void ShapeGraph::cutLines(const prefvec<Line>& lines, pqmap<int,pvecint>& axcuts)
-{
-   for (size_t i = 0; i < lines.size(); i ++) {
-      PixelRefVector pixels = pixelateLine(lines[i]);
-      pvecint testedshapes;
-      for (size_t j = 0; j < pixels.size(); j++) {
-         PixelRef pix = pixels[j];
-         pqvector<ShapeRef> &shapes = m_pixel_shapes[pix.x][pix.y];
-         for (size_t k = 0; k < shapes.size(); k++) {
-            ShapeRef& shape = shapes[k];
-            if (testedshapes.searchindex(shape.m_shape_ref) != paftl::npos) {
-               continue;
-            }
-            testedshapes.add(shape.m_shape_ref);
-            const Line& line = m_shapes.find(shape.m_shape_ref)->second.getLine();
-            //
-            if (intersect_region(line, lines[i], TOLERANCE_B * line.length()) ) {
-               if (intersect_line(line, lines[i], TOLERANCE_B * line.length())) {
-                  axcuts.search(shape.m_shape_ref).add(i);
-               }
-            }
-         }
       }
    }
 }
@@ -3083,7 +3081,7 @@ void ShapeGraph::makeNewSegMap()
 void ShapeGraph::makeSegmentMap(prefvec<Line>& lineset, prefvec<Connector>& connectionset, double stubremoval)
 {
    // the first (key) pair is the line / line intersection, second is the pair of associated segments for the first line
-   pqmap<OrderedIntPair,IntPair> segmentlist;
+   std::map<OrderedIntPair,IntPair> segmentlist;
 
    // this code relies on the polygon order being the same as the connections
 
@@ -3169,10 +3167,10 @@ void ShapeGraph::makeSegmentMap(prefvec<Line>& lineset, prefvec<Connector>& conn
             if (keylist[j] < (int)i) {
                // other line already segmented, look up in segment list,
                // and join segments together nicely
-               size_t index = segmentlist.searchindex(OrderedIntPair(keylist[j],i));
-               if (index != paftl::npos) {   // <- if it isn't -1 something has gone badly wrong!
-                  int seg_1 = segmentlist[index].a;
-                  int seg_2 = segmentlist[index].b;
+               auto segIter = segmentlist.find(OrderedIntPair(keylist[j],i));
+               if (segIter != segmentlist.end()) {   // <- if it isn't -1 something has gone badly wrong!
+                  int seg_1 = segIter->second.a;
+                  int seg_2 = segIter->second.b;
                   if (seg_a != -1) {
                      if (seg_1 != -1) {
                         Point2f alpha = lineset[seg_a].start() - lineset[seg_a].end();
@@ -3218,7 +3216,7 @@ void ShapeGraph::makeSegmentMap(prefvec<Line>& lineset, prefvec<Connector>& conn
             else {
                // other line still to be segmented, add ourselves to segment list
                // to be added later
-               segmentlist.add( OrderedIntPair(i,keylist[j]), IntPair(seg_a,seg_b) );
+               segmentlist.insert(std::make_pair( OrderedIntPair(i,keylist[j]), IntPair(seg_a,seg_b) ));
             }
          }
          if (seg_a != -1 && seg_b != -1) {
@@ -4274,53 +4272,53 @@ void TidyLines::tidy(prefvec<Line>& lines, const QtRegion& region)
    removelist.clear();  // always clear this list, it's reused
 }
 
-void TidyLines::quicktidy(pqmap<int,Line>& lines, const QtRegion& region)
+void TidyLines::quicktidy(std::map<int,Line>& lines, const QtRegion& region)
 {
    m_region = region;
 
    double avglen = 0.0;
-   size_t i;
-   for (i = 0; i < lines.size(); i++) {
-      avglen += lines[i].length();
+
+   for (auto line: lines) {
+      avglen += line.second.length();
    }
    avglen /= lines.size();
 
    double tolerance = avglen * 10e-6;
 
-   // simple first pass -- remove very short lines
-   pvecint removelist;
-   for (i = 0; i < lines.size(); i++) {
-      if (lines[i].length() < tolerance) {
-         removelist.add(i);
-      }
+   auto iter = lines.begin(), end = lines.end();
+   for(; iter != end; ) {
+       if (iter->second.length() < tolerance) {
+           iter = lines.erase(iter);
+       } else {
+           ++iter;
+       }
    }
-   if (removelist.size()) {
-      lines.remove_at(removelist);
-   }
-   removelist.clear();  // always clear this list, it's reused
 
    // now load up m_lines...
    initLines(lines.size(),m_region.bottom_left,m_region.top_right);
-   for (i = 0; i < lines.size(); i++) {
-      addLine(lines[i]);
+   for (auto line: lines) {
+      addLine(line.second);
    }
    sortPixelLines();
 
    // and chop duplicate lines:
-   for (i = 0; i < lines.size(); i++) {
-      PixelRef start = pixelate(lines[i].start());
-      for (size_t j = 0; j < m_pixel_lines[start.x][start.y].size(); j++) {
-         int k = m_pixel_lines[start.x][start.y][j];
-         if (k > (int)i && approxeq(m_lines[i].line.start(),m_lines[k].line.start(),tolerance)) {
-            if (approxeq(m_lines[i].line.end(),m_lines[k].line.end(),tolerance)) {
-               removelist.add(i);
-               break;
-            }
-         }
-      }
+
+   iter = lines.begin(), end = lines.end();
+   int i = -1;
+   for(; iter != end; ) {
+       i++;
+       PixelRef start = pixelate(iter->second.start());
+       for (size_t j = 0; j < m_pixel_lines[start.x][start.y].size(); j++) {
+          int k = m_pixel_lines[start.x][start.y][j];
+          if (k > (int)i && approxeq(m_lines[i].line.start(),m_lines[k].line.start(),tolerance)) {
+             if (approxeq(m_lines[i].line.end(),m_lines[k].line.end(),tolerance)) {
+                iter = lines.erase(iter);
+                break;
+             }
+          }
+       }
+       ++iter;
    }
-   lines.remove_at(removelist);
-   removelist.clear();  // always clear this list, it's reused}
 }
 
 /////////////////////////////////////////////////////

--- a/salalib/axialmap.h
+++ b/salalib/axialmap.h
@@ -32,7 +32,7 @@ class AxialPolygons : public SpacePixel
 {
    friend class ShapeGraphs;
 protected:
-   pqmap<Point2f,pqvector<Point2f>> m_vertex_possibles;
+   std::map<Point2f,pqvector<Point2f>> m_vertex_possibles;
    pvecint m_vertex_polys;
    pvecint **m_pixel_polys;
    pqvector<AxialVertex> m_handled_list;
@@ -195,8 +195,7 @@ public:
    virtual ~ShapeGraph() {;}
    void makeConnections(const prefvec<pvecint>& keyvertices = prefvec<pvecint>());
    //void initAttributes();
-   void makeDivisions(const prefvec<PolyConnector>& polyconnections, const pqvector<RadialLine>& radiallines, pqmap<RadialKey,pvecint>& radialdivisions, pqmap<int,pvecint>& axialdividers, Communicator *comm);
-   void cutLines(const prefvec<Line>& lines, pqmap<int,pvecint>& axcuts);
+   void makeDivisions(const prefvec<PolyConnector>& polyconnections, const pqvector<RadialLine>& radiallines, std::map<RadialKey, pvecint> &radialdivisions, std::map<int,pvecint>& axialdividers, Communicator *comm);
    bool integrate(Communicator *comm = NULL, const pvecint& radius = pvecint(), bool choice = false, bool local = false, bool fulloutput = false, int weighting_col = -1, bool simple_version = true);
    bool stepdepth(Communicator *comm = NULL);
    bool analyseAngular(Communicator *comm, const pvecdouble& radius);
@@ -264,7 +263,7 @@ public:
    TidyLines() {;}
    virtual ~TidyLines() {;}
    void tidy(prefvec<Line>& lines, const QtRegion& region);  
-   void quicktidy(pqmap<int,Line>& lines, const QtRegion& region);
+   void quicktidy(std::map<int, Line> &lines, const QtRegion& region);
 };
 
 // helpers... a class to reduce all line maps to fewest line maps
@@ -282,12 +281,12 @@ protected:
    int *m_keyvertexcounts;
    prefvec<Connector> m_axialconns; // <- uses a copy of axial lines as it will remove connections
 public:
-   AxialMinimiser(const ShapeGraph& alllinemap, pqmap<int,pvecint>& axsegcuts, pqmap<RadialKey,RadialSegment>& radialsegs);
+   AxialMinimiser(const ShapeGraph& alllinemap, std::map<int,pvecint>& axsegcuts, std::map<RadialKey,RadialSegment>& radialsegs);
    ~AxialMinimiser();
-   void removeSubsets(pqmap<int,pvecint>& axsegcuts, pqmap<RadialKey,RadialSegment>& radialsegs, pqmap<RadialKey,pvecint>& rlds, pqvector<RadialLine>& radial_lines, prefvec<pvecint>& keyvertexconns, int *keyvertexcounts);
-   void fewestLongest(pqmap<int,pvecint>& axsegcuts, pqmap<RadialKey,RadialSegment>& radialsegs, pqmap<RadialKey,pvecint>& rlds, pqvector<RadialLine>& radial_lines, prefvec<pvecint>& keyvertexconns, int *keyvertexcounts);
+   void removeSubsets(std::map<int,pvecint>& axsegcuts, std::map<RadialKey,RadialSegment>& radialsegs, std::map<RadialKey,pvecint>& rlds, pqvector<RadialLine>& radial_lines, prefvec<pvecint>& keyvertexconns, int *keyvertexcounts);
+   void fewestLongest(std::map<int,pvecint>& axsegcuts, std::map<RadialKey,RadialSegment>& radialsegs, std::map<RadialKey,pvecint>& rlds, pqvector<RadialLine>& radial_lines, prefvec<pvecint>& keyvertexconns, int *keyvertexcounts);
    // advanced topological testing:
-   bool checkVital(int checkindex,pvecint& axsegcuts, pqmap<RadialKey,RadialSegment>& radialsegs, pqmap<RadialKey,pvecint>& rlds, pqvector<RadialLine>& radial_lines);
+   bool checkVital(int checkindex,pvecint& axsegcuts, std::map<RadialKey,RadialSegment>& radialsegs, std::map<RadialKey,pvecint>& rlds, pqvector<RadialLine>& radial_lines);
    //
    bool removed(int i) const
    { return m_removed[i]; }

--- a/salalib/mgraph.cpp
+++ b/salalib/mgraph.cpp
@@ -1630,16 +1630,17 @@ int MetaGraph::loadRT1(const std::vector<string>& fileset, Communicator *communi
    SuperSpacePixel::tail().m_region = QtRegion(map.getBottomLeft(), map.getTopRight());
 
    // for each category
-   for (size_t i = 0; i < map.size(); i++) {
-
-      SuperSpacePixel::tail().push_back(ShapeMap(map.key(i)));
-      SuperSpacePixel::tail().at(i).init(map.value(i).size(), map.getRegion() );
+   int i = -1;
+   for (auto val: map) {
+      i++;
+      SuperSpacePixel::tail().push_back(ShapeMap(val.first));
+      SuperSpacePixel::tail().at(i).init(val.second.size(), map.getRegion() );
 
       // for each chains in category:
-      for (size_t j = 0; j < map.value(i).size(); j++) {
+      for (size_t j = 0; j < val.second.size(); j++) {
          // for each node pair in each category
-         for (size_t k = 0; k < map.value(i).at(j).size(); k++) {
-            SuperSpacePixel::tail().at(i).makeLineShape( map.value(i).at(j).at(k) );   
+         for (size_t k = 0; k < val.second.at(j).size(); k++) {
+            SuperSpacePixel::tail().at(i).makeLineShape( val.second.at(j).at(k) );
          }
       }
 

--- a/salalib/mgraph.cpp
+++ b/salalib/mgraph.cpp
@@ -648,7 +648,7 @@ bool MetaGraph::makeBSPtree(Communicator *communicator)
          if (SuperSpacePixel::at(i).at(j).isShown()) {
              auto refShapes = SuperSpacePixel::at(i).at(j).getAllShapes();
              int k = -1;
-             for (auto refShape: refShapes) {
+             for (auto& refShape: refShapes) {
                  k++;
                  SalaShape& shape = refShape.second;
                // I'm not sure what the tagging was meant for any more, 
@@ -958,7 +958,7 @@ bool MetaGraph::convertToData(Communicator *comm, std::string layer_name, bool k
             for (size_t j = 0; j < SuperSpacePixel::at(i).size(); j++) {
                if (SuperSpacePixel::at(i).at(j).isShown()) {
                   auto refShapes = SuperSpacePixel::at(i).at(j).getAllShapes();
-                  for (auto refShape: refShapes) {
+                  for (auto& refShape: refShapes) {
                      int key = destmap.makeShape(refShape.second);
                      table.setValue(table.getRowid(key),layercol,float(j+1));
                      count++;
@@ -1631,7 +1631,7 @@ int MetaGraph::loadRT1(const std::vector<string>& fileset, Communicator *communi
 
    // for each category
    int i = -1;
-   for (auto val: map) {
+   for (auto& val: map) {
       i++;
       SuperSpacePixel::tail().push_back(ShapeMap(val.first));
       SuperSpacePixel::tail().at(i).init(val.second.size(), map.getRegion() );

--- a/salalib/mgraph.cpp
+++ b/salalib/mgraph.cpp
@@ -1892,12 +1892,12 @@ int MetaGraph::convertDataLayersToShapeMap(DataLayers& datalayers, PointMap& poi
 {
    int retvar = 1;
    // check for existence of data:
-   pmap<int,int> conversion_lookup;
+   std::map<int,int> conversion_lookup;
    size_t i;
    for (i = 0; i < size_t(datalayers.getLayerCount()); i++) {
       if (datalayers[i].getObjectCount()) {
          int x = m_data_maps.addMap(datalayers[i].getLayerName(),ShapeMap::DATAMAP);
-         conversion_lookup.add(i,x);
+         conversion_lookup.insert(std::make_pair(i,x));
       }
    }
    // nothing to convert:
@@ -1906,7 +1906,7 @@ int MetaGraph::convertDataLayersToShapeMap(DataLayers& datalayers, PointMap& poi
    }
 
    for (i = 0; i < conversion_lookup.size(); i++) {
-      ShapeMap& shapemap = m_data_maps.getMap(conversion_lookup.value(i));
+      ShapeMap& shapemap = m_data_maps.getMap(depthmapX::getMapAtIndex(conversion_lookup, i)->second);
       int j;
       // add shapes:
       pvecint row_lookup;

--- a/salalib/mgraph.h
+++ b/salalib/mgraph.h
@@ -157,7 +157,6 @@ public:
    //
    // some compatibility with older version horrors:
    int convertDataLayersToShapeMap(DataLayers& datalayers, PointMap& pointmap);
-   void convertShapeGraphToShapeMap(const ShapeGraph& axialmap);
    //
    int loadMifMap(Communicator *comm, istream& miffile, istream& midfile);
    bool makeAllLineMap( Communicator *communicator, const Point2f& seed );

--- a/salalib/pointdata.cpp
+++ b/salalib/pointdata.cpp
@@ -918,14 +918,14 @@ void PointMap::outputNet(ostream& netfile)
 {
    // this is a bid of a faff, as we first have to get the point locations, 
    // then the connections from a lookup table... ickity ick ick...
-   pmap<PixelRef,PixelRefVector> graph;
+   std::map<PixelRef,PixelRefVector> graph;
    for (int i = 0; i < m_cols; i++) {
       for (int j = 0; j < m_rows; j++) {
          if (m_points[i][j].filled() && m_points[i][j].m_node) {
             PixelRef pix(i,j);
             PixelRefVector connections;
             m_points[i][j].m_node->contents(connections);
-            graph.add(pix,connections);
+            graph.insert(std::make_pair(pix,connections));
          }
       }
    }
@@ -933,16 +933,17 @@ void PointMap::outputNet(ostream& netfile)
    double maxdim = __max(m_region.width(),m_region.height());
    Point2f offset = Point2f((maxdim - m_region.width())/(2.0*maxdim),(maxdim - m_region.height())/(2.0*maxdim));
    for (size_t j = 0; j < graph.size(); j++) {
-      Point2f p = depixelate(graph.key(j));
+      auto graphKey = depthmapX::getMapAtIndex(graph, j)->first;
+      Point2f p = depixelate(graphKey);
       p.x = offset.x + (p.x - m_region.bottom_left.x) / maxdim;
       p.y = 1.0 - (offset.y + (p.y - m_region.bottom_left.y) / maxdim);
-      netfile << (j+1) << " \"" << graph.key(j) << "\" " << p.x << " " << p.y << endl;
+      netfile << (j+1) << " \"" << graphKey << "\" " << p.x << " " << p.y << endl;
    }
    netfile << "*Edges" << endl;
    for (size_t k = 0; k < graph.size(); k++) {
-      PixelRefVector& list = graph.value(k);
+      PixelRefVector& list = depthmapX::getMapAtIndex(graph, k)->second;
       for (size_t m = 0; m < list.size(); m++) {
-         size_t n = graph.searchindex(list[m]);
+         size_t n = depthmapX::findIndexFromKey(graph, list[m]);
          if (n != paftl::npos && k < n) {
             netfile << (k+1) << " " << (n+1) << " 1" << endl;
          }

--- a/salalib/pointdata.cpp
+++ b/salalib/pointdata.cpp
@@ -442,8 +442,9 @@ bool PointMap::fillLines()
    for (size_t file = 0; file < m_spacepix->size(); file++) {
       for (size_t layer = 0; layer < m_spacepix->at(file).size(); layer++) {
          if (m_spacepix->at(file).at(layer).isShown()) {
-            for (size_t k = 0; k < m_spacepix->at(file).at(layer).getAllShapes().size(); k++) {
-               SalaShape& shape = m_spacepix->at(file).at(layer).getAllShapes().at(k);
+            auto refShapes = m_spacepix->at(file).at(layer).getAllShapes();
+            for (auto refShape: refShapes) {
+               SalaShape& shape = refShape.second;
                if (shape.isLine()) {
                   fillLine(shape.getLine());
                }
@@ -494,8 +495,9 @@ bool PointMap::blockLines()
       for (size_t j = 0; j < m_spacepix->at(i).size(); j++) {
          // chooses the first editable layer it can find:
          if (m_spacepix->at(i).at(j).isShown()) {
-            for (size_t k = 0; k < m_spacepix->at(i).at(j).getAllShapes().size(); k++) {
-               SalaShape& shape = m_spacepix->at(i).at(j).getAllShapes().at(k);
+             auto refShapes = m_spacepix->at(i).at(j).getAllShapes();
+             for (auto refShape: refShapes) {
+                 SalaShape& shape = refShape.second;
                if (shape.isLine()) {
                   blockLine(count++,shape.getLine());
                }
@@ -3354,9 +3356,9 @@ bool PointMap::mergePixels(PixelRef a, PixelRef b)
 
 void PointMap::mergeFromShapeMap(const ShapeMap& shapemap)
 {
-   const pqmap<int,SalaShape>& polygons = shapemap.getAllShapes();
-   for (size_t i = 0; i < polygons.size(); i++) {
-      const SalaShape& poly = polygons[i];
+   const std::map<int,SalaShape>& polygons = shapemap.getAllShapes();
+   for (auto polygon: polygons) {
+      const SalaShape& poly = polygon.second;
       if (poly.isLine()) {
          PixelRef a = pixelate(poly.getLine().start());
          PixelRef b = pixelate(poly.getLine().end());

--- a/salalib/pointdata.cpp
+++ b/salalib/pointdata.cpp
@@ -443,7 +443,7 @@ bool PointMap::fillLines()
       for (size_t layer = 0; layer < m_spacepix->at(file).size(); layer++) {
          if (m_spacepix->at(file).at(layer).isShown()) {
             auto refShapes = m_spacepix->at(file).at(layer).getAllShapes();
-            for (auto refShape: refShapes) {
+            for (auto& refShape: refShapes) {
                SalaShape& shape = refShape.second;
                if (shape.isLine()) {
                   fillLine(shape.getLine());
@@ -496,7 +496,7 @@ bool PointMap::blockLines()
          // chooses the first editable layer it can find:
          if (m_spacepix->at(i).at(j).isShown()) {
              auto refShapes = m_spacepix->at(i).at(j).getAllShapes();
-             for (auto refShape: refShapes) {
+             for (auto& refShape: refShapes) {
                  SalaShape& shape = refShape.second;
                if (shape.isLine()) {
                   blockLine(count++,shape.getLine());
@@ -3358,7 +3358,7 @@ bool PointMap::mergePixels(PixelRef a, PixelRef b)
 void PointMap::mergeFromShapeMap(const ShapeMap& shapemap)
 {
    const std::map<int,SalaShape>& polygons = shapemap.getAllShapes();
-   for (auto polygon: polygons) {
+   for (auto& polygon: polygons) {
       const SalaShape& poly = polygon.second;
       if (poly.isLine()) {
          PixelRef a = pixelate(poly.getLine().start());

--- a/salalib/salaprogram.cpp
+++ b/salalib/salaprogram.cpp
@@ -1078,7 +1078,7 @@ void SalaCommand::evaluate(SalaObj& obj, bool& ret, bool& ifhandled)
             if (len != 0) {
                for (int i = 0; i < len; i++) {
                   // reset all my stack (actually, all parent functions should do this!)
-                  for (auto varName: m_var_names) {
+                  for (auto& varName: m_var_names) {
                      m_program->m_var_stack[varName.second].uninit();
                   }
                   m_program->m_var_stack[m_for_iter.data.var] = list.data.list.list->at(i);

--- a/salalib/salaprogram.h
+++ b/salalib/salaprogram.h
@@ -22,6 +22,7 @@
 #include "genlib/stringutils.h"
 #include <vector>
 #include <set>
+#include <map>
 
 class AttributeTable;
 class PointMap;
@@ -265,7 +266,7 @@ protected:
    SalaCommand *m_parent;
    prefvec<SalaCommand> m_children;
    //
-   pqmap<std::string,int> m_var_names;
+   std::map<std::string,int> m_var_names;
    //
    Command m_command;
    int m_indent;  // vital for program flow due to Pythonesque syntax

--- a/salalib/shapemap.cpp
+++ b/salalib/shapemap.cpp
@@ -2638,8 +2638,8 @@ bool ShapeMap::read( istream& stream, int version, bool drawinglayer )
    for (int k = 0; k < count; k++) {
       int key;
       stream.read((char *) &key, sizeof(key));
-      int index = m_objects.add(key, SalaObject());
-      m_objects.value(index).read(stream,version);
+      m_objects.insert(std::make_pair(key, SalaObject()));
+      m_objects.end()->second.read(stream,version);
    }
    // read attribute data
    m_attributes.read(stream,version);
@@ -2716,10 +2716,10 @@ bool ShapeMap::write( ofstream& stream, int version )
    // write object data (currently unused)
    count = m_objects.size();
    stream.write((char *) &count, sizeof(count));
-   for (int k = 0; k < count; k++) {
-      int key = m_objects.key(k);
+   for (auto obj: m_objects) {
+      int key = obj.first;
       stream.write((char *) &key, sizeof(key));
-      m_objects.value(k).write(stream);
+      obj.second.write(stream);
    }
    // write attribute data
    m_attributes.write(stream,version);

--- a/salalib/shapemap.cpp
+++ b/salalib/shapemap.cpp
@@ -541,30 +541,30 @@ int ShapeMap::makeShapeFromPointSet(const PointMap& pointmap)
       QtRegion r(pointmap.getRegion().bottom_left - offset,pointmap.getRegion().top_right + offset);
       init(m_shapes.size(),r);
    }
-   pmap<int,int> relations;
+   std::map<int,int> relations;
    for (size_t j = 0; j < selset.size(); j++) {
       PixelRef pix = selset[j];
-      int x = relations.add(pix,ShapeRef::SHAPE_EDGE);
+      auto relation = relations.insert(std::make_pair(pix,ShapeRef::SHAPE_EDGE));
       if (pointmap.includes(pix.right()) && pointmap.getPoint(pix.right()).selected()) {
-         relations.value(x) &= ~ShapeRef::SHAPE_R;
+         relation.second &= ~ShapeRef::SHAPE_R;
       }
       if (pointmap.includes(pix.up()) && pointmap.getPoint(pix.up()).selected()) {
-         relations.value(x) &= ~ShapeRef::SHAPE_T;
+         relation.second &= ~ShapeRef::SHAPE_T;
       }
       if (pointmap.includes(pix.down()) && pointmap.getPoint(pix.down()).selected()) {
-         relations.value(x) &= ~ShapeRef::SHAPE_B;
+         relation.second &= ~ShapeRef::SHAPE_B;
       }
       if (pointmap.includes(pix.left()) && pointmap.getPoint(pix.left()).selected()) {
-         relations.value(x) &= ~ShapeRef::SHAPE_L;
+         relation.second &= ~ShapeRef::SHAPE_L;
       }
    }
    // now find pixel with SHAPE_B | SHAPE_L
    PixelRef minpix = NoPixel;
-   size_t k;
-   for (k = 0; k < relations.size(); k++) {
-      if ((relations.value(k) & (ShapeRef::SHAPE_B | ShapeRef::SHAPE_L)) == (ShapeRef::SHAPE_B | ShapeRef::SHAPE_L)) {
-         if ((minpix == NoPixel) || (relations.key(k) < (int)minpix)) {
-            minpix = relations.key(k);
+
+   for (auto relation: relations) {
+      if ((relation.second & (ShapeRef::SHAPE_B | ShapeRef::SHAPE_L)) == (ShapeRef::SHAPE_B | ShapeRef::SHAPE_L)) {
+         if ((minpix == NoPixel) || (relation.first < (int)minpix)) {
+            minpix = relation.first;
          }
       }
    }
@@ -574,8 +574,8 @@ int ShapeMap::makeShapeFromPointSet(const PointMap& pointmap)
 
    bool retvar = true;
 
-   for (k = 0; k < relations.size(); k++) {
-      if (relations[k] != 0) {
+   for (auto relation: relations) {
+      if (relation.second != 0) {
          // more than one shape!
          return -1;
       }
@@ -1203,7 +1203,7 @@ void ShapeMap::makePolyPixels(int polyref)
    // first add into pixels, and ensure you have a bl, tr for the set (useful for testing later)
    SalaShape& poly = m_shapes.find(polyref)->second;
    if (poly.isClosed()) {
-      pmap<int,int> relations;
+      std::map<int,int> relations;
       for (size_t k = 0; k < poly.size(); k++) {
          int nextk = (k + 1) % poly.size();
          Line li(poly[k],poly[nextk]);
@@ -1224,42 +1224,42 @@ void ShapeMap::makePolyPixels(int polyref)
                x = m_pixel_shapes[pix.x][pix.y].add(ShapeRef(polyref),paftl::ADD_HERE);
             }
             m_pixel_shapes[pix.x][pix.y][x].m_polyrefs.push_back(k);
-            relations.add(pixels[i],ShapeRef::SHAPE_EDGE);
+            relations.insert(std::make_pair(pixels[i],ShapeRef::SHAPE_EDGE));
          }
       }
       // erase joined sides, and look for min:
       PixelRef minpix = NoPixel; 
-      for (size_t j = 0; j < relations.size(); j++) {
-         PixelRef pix = relations.key(j);
+      for (auto relation: relations) {
+         PixelRef pix = relation.first;
          PixelRef nextpix;
          nextpix = pix.right();
          if (includes(nextpix) && m_pixel_shapes[nextpix.x][nextpix.y].searchindex(ShapeRef(polyref)) != paftl::npos) {
-            relations.value(j) &= ~ShapeRef::SHAPE_R;
+            relation.second &= ~ShapeRef::SHAPE_R;
          }
          nextpix = pix.up();
          if (includes(nextpix) && m_pixel_shapes[nextpix.x][nextpix.y].searchindex(ShapeRef(polyref)) != paftl::npos) {
-            relations.value(j) &= ~ShapeRef::SHAPE_T;
+            relation.second &= ~ShapeRef::SHAPE_T;
          }
          nextpix = pix.down();
          if (includes(nextpix) && m_pixel_shapes[nextpix.x][nextpix.y].searchindex(ShapeRef(polyref)) != paftl::npos) {
-            relations.value(j) &= ~ShapeRef::SHAPE_B;
+            relation.second &= ~ShapeRef::SHAPE_B;
          }
          nextpix = pix.left();
          if (includes(nextpix) && m_pixel_shapes[nextpix.x][nextpix.y].searchindex(ShapeRef(polyref)) != paftl::npos) {
-            relations.value(j) &= ~ShapeRef::SHAPE_L;
+            relation.second &= ~ShapeRef::SHAPE_L;
          }
-         if ((relations.value(j) & (ShapeRef::SHAPE_B | ShapeRef::SHAPE_L)) == (ShapeRef::SHAPE_B | ShapeRef::SHAPE_L)) {
-            if ((minpix == NoPixel) || (relations.key(j) < (int)minpix)) {
-               minpix = relations.key(j);
+         if ((relation.second & (ShapeRef::SHAPE_B | ShapeRef::SHAPE_L)) == (ShapeRef::SHAPE_B | ShapeRef::SHAPE_L)) {
+            if ((minpix == NoPixel) || (relation.first < (int)minpix)) {
+               minpix = relation.first;
             }
          }
       }
       shapePixelBorder(relations,polyref,ShapeRef::SHAPE_L,minpix,minpix,true);
       // go through any that aren't on the outer border: this will be internal edges, and will cause problems
       // for point in polygon algorithms!
-      size_t i;
-      for (i = 0; i < relations.size(); i++) {
-         PixelRef pix = relations.key(i);
+
+      for (auto relation: relations) {
+         PixelRef pix = relation.first;
          unsigned char& tags = m_pixel_shapes[pix.x][pix.y].search(polyref).m_tags;
          if (tags == 0x00) {
             tags |= ShapeRef::SHAPE_INTERNAL_EDGE;
@@ -1267,9 +1267,9 @@ void ShapeMap::makePolyPixels(int polyref)
       }
       // now, any remaining tags are internal sides, and need to be cleared through fill
       // we could go either direction, but we just go left to right:
-      for (i = 0; i < relations.size(); i++) {
-         PixelRef pix = relations.key(i);
-         if (relations.value(i) & ShapeRef::SHAPE_R) {
+      for (auto relation: relations) {
+         PixelRef pix = relation.first;
+         if (relation.second & ShapeRef::SHAPE_R) {
             int pos = 0;
             do {
                PixelRef nextpix = pix.right();
@@ -1337,16 +1337,16 @@ void ShapeMap::makePolyPixels(int polyref)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-void ShapeMap::shapePixelBorder(pmap<int,int>& relations, int polyref, int side, PixelRef currpix, PixelRef minpix, bool first) 
+void ShapeMap::shapePixelBorder(std::map<int,int>& relations, int polyref, int side, PixelRef currpix, PixelRef minpix, bool first)
 {
    if (!first && currpix == minpix && side == ShapeRef::SHAPE_L) {
       // looped:
       return;
    }
-   size_t rel = relations.searchindex(currpix);
-   if (relations[rel] & side) {
+   auto relation = relations.find(currpix);
+   if (relation->second & side) {
       m_pixel_shapes[currpix.x][currpix.y].search(polyref).m_tags |= side;
-      relations[rel] &= ~side;   // <- clear to check all have been done later
+      relation->second &= ~side;   // <- clear to check all have been done later
       side <<= 1;
       if (side > ShapeRef::SHAPE_T) {
          side = ShapeRef::SHAPE_L;
@@ -1364,16 +1364,16 @@ void ShapeMap::shapePixelBorder(pmap<int,int>& relations, int polyref, int side,
 }
 
 // note that this is almost exactly the same as shapePixelBorder
-void ShapeMap::pointPixelBorder(const PointMap& pointmap, pmap<int,int>& relations, SalaShape& poly, int side, PixelRef currpix, PixelRef minpix, bool first) 
+void ShapeMap::pointPixelBorder(const PointMap& pointmap, std::map<int,int>& relations, SalaShape& poly, int side, PixelRef currpix, PixelRef minpix, bool first)
 {
    if (!first && currpix == minpix && side == ShapeRef::SHAPE_L) {
       // looped:
       return;
    }
-   size_t rel = relations.searchindex(currpix);
-   if (relations[rel] & side) {
+   auto relation = relations.find(currpix);
+   if (relation->second & side) {
       poly.push_back(pointmap.depixelate(currpix)+pointOffset(pointmap,currpix,side));
-      relations[rel] &= ~side;   // <- clear to check all have been done later
+      relation->second &= ~side;   // <- clear to check all have been done later
       side <<= 1;
       if (side > ShapeRef::SHAPE_T) {
          side = ShapeRef::SHAPE_L;
@@ -3837,26 +3837,26 @@ bool ShapeMap::ozlemSpecial4(ValuePair& cut, IntPair& previous, int& state, Attr
 // expects to be the rays layer... check intersection of each ray with *all* O.S. polys
 void ShapeMap::ozlemSpecial5(ShapeMap& buildings)
 {
-   pmap<int,int> exposureranks;
-   exposureranks.add(10172,10);
-   exposureranks.add(10183,9);
-   exposureranks.add(10056,8);
-   exposureranks.add(10054,7);
-   exposureranks.add(10123,6);
-   exposureranks.add(10119,5);
-   exposureranks.add(10111,4);
-   exposureranks.add(10217,3);
-   exposureranks.add(10167,2);
-   exposureranks.add(10089,1);
-   exposureranks.add(10053,0);
-   exposureranks.add(-1,-1);
+   std::map<int,int> exposureranks;
+   exposureranks.insert(std::make_pair(10172,10));
+   exposureranks.insert(std::make_pair(10183,9));
+   exposureranks.insert(std::make_pair(10056,8));
+   exposureranks.insert(std::make_pair(10054,7));
+   exposureranks.insert(std::make_pair(10123,6));
+   exposureranks.insert(std::make_pair(10119,5));
+   exposureranks.insert(std::make_pair(10111,4));
+   exposureranks.insert(std::make_pair(10217,3));
+   exposureranks.insert(std::make_pair(10167,2));
+   exposureranks.insert(std::make_pair(10089,1));
+   exposureranks.insert(std::make_pair(10053,0));
+   exposureranks.insert(std::make_pair(-1,-1));
 
    int inorientcol = m_attributes.getColumnIndex("Orientation");
    int incodecol = m_attributes.getColumnIndex("FeatureCode");
    //
    for (int ii = 0; ii < m_attributes.getRowCount(); ii++) {
       int featcode = (int)m_attributes.getValue(ii,incodecol);
-      if (exposureranks.searchindex(featcode) == paftl::npos) {
+      if (exposureranks.find(featcode) == exposureranks.end()) {
          std::string blah = dXstring::formatString(featcode,"Error: wasn't expecting feature code %d");
          // Quick mod - TV
          // MessageBox(NULL,blah.c_str(),"Error: ozlemSpecial5",MB_OK|MB_ICONEXCLAMATION);
@@ -3942,7 +3942,7 @@ void ShapeMap::ozlemSpecial5(ShapeMap& buildings)
                else {
                   buildings.m_attributes.setValue(browid,outtypecol,3);
                }
-               if (exposureranks.search(exposurelist[0].b) > exposureranks.search(exposurelist[1].b)) {
+               if (exposureranks.find(exposurelist[0].b)->second > exposureranks.find(exposurelist[1].b)->second) {
                   buildings.m_attributes.setValue(browid,outprimcol,(float)exposurelist[0].b);
                   buildings.m_attributes.setValue(browid,outsecocol,(float)exposurelist[1].b);
                }
@@ -3963,11 +3963,11 @@ void ShapeMap::ozlemSpecial5(ShapeMap& buildings)
                            rearexposed = true;
                         }
                      }
-                     if (exposureranks.search(exposurelist[i].b) > exposureranks.search(prim)) {
+                     if (exposureranks.find(exposurelist[i].b)->second > exposureranks.find(prim)->second) {
                         seco = prim;
                         prim = exposurelist[i].b;
                      }
-                     else if (exposureranks.search(exposurelist[i].b) > exposureranks.search(seco)) {
+                     else if (exposureranks.find(exposurelist[i].b)->second > exposureranks.find(seco)->second) {
                         seco = exposurelist[i].b;
                      }
                   }
@@ -3982,11 +3982,11 @@ void ShapeMap::ozlemSpecial5(ShapeMap& buildings)
                   buildings.m_attributes.setValue(browid,outtypecol,4);
                   int prim = -1, seco = -1;
                   for (int i = 0; i < 4; i++) {
-                     if (exposureranks.search(exposurelist[i].b) > exposureranks.search(prim)) {
+                     if (exposureranks.find(exposurelist[i].b)->second > exposureranks.find(prim)->second) {
                         seco = prim;
                         prim = exposurelist[i].b;
                      }
-                     else if (exposureranks.search(exposurelist[i].b) > exposureranks.search(seco)) {
+                     else if (exposureranks.find(exposurelist[i].b)->second > exposureranks.find(seco)->second) {
                         seco = exposurelist[i].b;
                      }
                   }

--- a/salalib/shapemap.cpp
+++ b/salalib/shapemap.cpp
@@ -239,7 +239,7 @@ void ShapeMap::copy(const ShapeMap& sourcemap, int copyflags)
       m_shapes.clear();
       m_shape_ref = -1;
       init(sourcemap.m_shapes.size(),sourcemap.m_region);
-      for (auto shape: sourcemap.m_shapes) {
+      for (auto& shape: sourcemap.m_shapes) {
          // using makeShape is actually easier than thinking about a total copy:
          makeShape(shape.second, shape.first);
          // note that addShape automatically adds the attribute row
@@ -332,7 +332,7 @@ int ShapeMap::makePointShape(const Point2f& point, bool tempshape)
    }
    else {
       // pixelate all polys in the pixel new structure:
-      for (auto shape: m_shapes) {
+      for (auto& shape: m_shapes) {
          makePolyPixels(shape.first);
       }
    }
@@ -369,7 +369,7 @@ int ShapeMap::makeLineShape(const Line& line, bool through_ui, bool tempshape)
    }
    else {
       // pixelate all polys in the pixel new structure:
-      for (auto shape: m_shapes) {
+      for (auto& shape: m_shapes) {
          makePolyPixels(shape.first);
       }
    }
@@ -453,7 +453,7 @@ int ShapeMap::makePolyShape(const pqvector<Point2f>& points, bool open, bool tem
    }
    else {
       // pixelate all polys in the pixel new structure:
-      for (auto shape: m_shapes) {
+      for (auto& shape: m_shapes) {
          makePolyPixels(shape.first);
       }
    }
@@ -502,7 +502,7 @@ int ShapeMap::makeShape(const SalaShape& poly, int override_shape_ref)
    }
    else {
       // pixelate all polys in the pixel new structure:
-      for (auto shape: m_shapes) {
+      for (auto& shape: m_shapes) {
          makePolyPixels(shape.first);
       }
    }
@@ -561,7 +561,7 @@ int ShapeMap::makeShapeFromPointSet(const PointMap& pointmap)
    // now find pixel with SHAPE_B | SHAPE_L
    PixelRef minpix = NoPixel;
 
-   for (auto relation: relations) {
+   for (auto& relation: relations) {
       if ((relation.second & (ShapeRef::SHAPE_B | ShapeRef::SHAPE_L)) == (ShapeRef::SHAPE_B | ShapeRef::SHAPE_L)) {
          if ((minpix == NoPixel) || (relation.first < (int)minpix)) {
             minpix = relation.first;
@@ -574,7 +574,7 @@ int ShapeMap::makeShapeFromPointSet(const PointMap& pointmap)
 
    bool retvar = true;
 
-   for (auto relation: relations) {
+   for (auto& relation: relations) {
       if (relation.second != 0) {
          // more than one shape!
          return -1;
@@ -591,7 +591,7 @@ int ShapeMap::makeShapeFromPointSet(const PointMap& pointmap)
    }
    else {
       // pixelate all polys in the pixel new structure:
-      for (auto shape: m_shapes) {
+      for (auto& shape: m_shapes) {
          makePolyPixels(shape.first);
       }
    }
@@ -613,7 +613,7 @@ bool ShapeMap::convertPointsToPolys(double poly_radius, bool selected_only)
 
    // replace the points with polys
    int i = -1;
-   for (auto shape: m_shapes) {
+   for (auto& shape: m_shapes) {
       i++;
       if (selected_only && !m_attributes.isSelected(i)) {
          continue;
@@ -651,7 +651,7 @@ bool ShapeMap::convertPointsToPolys(double poly_radius, bool selected_only)
       // spatially reindex (simplest just to redo everything)
       init(m_shapes.size(),region);
 
-      for (auto shape: m_shapes) {
+      for (auto& shape: m_shapes) {
          makePolyPixels(shape.first);
       }
    }
@@ -693,7 +693,7 @@ bool ShapeMap::moveShape(int shaperef, const Line& line, bool undoing)
    }
    else {
       // pixelate all polys in the pixel new structure:
-      for (auto shape: m_shapes) {
+      for (auto& shape: m_shapes) {
          makePolyPixels(shape.first);
       }
    }
@@ -812,7 +812,7 @@ int ShapeMap::polyBegin(const Line& line)
    }
    else {
       // pixelate all polys in the pixel new structure:
-      for (auto shape: m_shapes) {
+      for (auto& shape: m_shapes) {
          makePolyPixels(shape.first);
       }
    }
@@ -876,7 +876,7 @@ bool ShapeMap::polyAppend(const Point2f& point)
    }
    else {
       // pixelate all polys in the pixel new structure:
-      for (auto shape: m_shapes) {
+      for (auto& shape: m_shapes) {
          makePolyPixels(shape.first);
       }
    }
@@ -999,7 +999,7 @@ void ShapeMap::shapesCommit()
 {
    init(m_shapes.size(),m_region);
 
-   for (auto shape: m_shapes) {
+   for (auto& shape: m_shapes) {
       makePolyPixels(shape.first);
    }
 
@@ -1229,7 +1229,7 @@ void ShapeMap::makePolyPixels(int polyref)
       }
       // erase joined sides, and look for min:
       PixelRef minpix = NoPixel; 
-      for (auto relation: relations) {
+      for (auto& relation: relations) {
          PixelRef pix = relation.first;
          PixelRef nextpix;
          nextpix = pix.right();
@@ -1258,7 +1258,7 @@ void ShapeMap::makePolyPixels(int polyref)
       // go through any that aren't on the outer border: this will be internal edges, and will cause problems
       // for point in polygon algorithms!
 
-      for (auto relation: relations) {
+      for (auto& relation: relations) {
          PixelRef pix = relation.first;
          unsigned char& tags = m_pixel_shapes[pix.x][pix.y].search(polyref).m_tags;
          if (tags == 0x00) {
@@ -1267,7 +1267,7 @@ void ShapeMap::makePolyPixels(int polyref)
       }
       // now, any remaining tags are internal sides, and need to be cleared through fill
       // we could go either direction, but we just go left to right:
-      for (auto relation: relations) {
+      for (auto& relation: relations) {
          PixelRef pix = relation.first;
          if (relation.second & ShapeRef::SHAPE_R) {
             int pos = 0;
@@ -2415,7 +2415,7 @@ void ShapeMap::makeShapeConnections()
       int conn_col = m_attributes.insertLockedColumn("Connectivity");
 
       int i = -1;
-      for (auto shape: m_shapes) {
+      for (auto& shape: m_shapes) {
          i++;
          int key = shape.first;
          int rowid = m_attributes.insertRow(key);
@@ -2488,7 +2488,7 @@ bool ShapeMap::setCurSel( QtRegion& r, bool add )
       }
       // actually probably often faster to set flag and later record list:
       int x = -1;
-      for (auto shape: m_shapes) {
+      for (auto& shape: m_shapes) {
          x++;
          if (shape.second.m_selected) {
              if(m_selection_set.insert(x).second) {
@@ -2667,7 +2667,7 @@ bool ShapeMap::read( istream& stream, int version, bool drawinglayer )
    }
    // Now add the pixel shapes pixel map:
    // pixelate all polys in the pixel structure:
-   for (auto shape: m_shapes) {
+   for (auto& shape: m_shapes) {
       makePolyPixels(shape.first);
    }
 
@@ -2722,7 +2722,7 @@ bool ShapeMap::write( ofstream& stream, int version )
    // write shape data
    int count = m_shapes.size();
    stream.write((char *) &count, sizeof(count));
-   for (auto shape: m_shapes) {
+   for (auto& shape: m_shapes) {
       int key = shape.first;
       stream.write((char *) &key, sizeof(key));
       shape.second.write(stream);
@@ -2730,7 +2730,7 @@ bool ShapeMap::write( ofstream& stream, int version )
    // write object data (currently unused)
    count = m_objects.size();
    stream.write((char *) &count, sizeof(count));
-   for (auto obj: m_objects) {
+   for (auto& obj: m_objects) {
       int key = obj.first;
       stream.write((char *) &key, sizeof(key));
       obj.second.write(stream);
@@ -3393,7 +3393,7 @@ bool ShapeMap::makeBSPtree() const
    }
 
    std::vector<TaggedLine> partitionlines;
-   for (auto shape: m_shapes) {
+   for (auto& shape: m_shapes) {
       if (shape.second.isLine()) {
          partitionlines.push_back(TaggedLine(shape.second.getLine(),shape.first));
       }
@@ -3563,7 +3563,7 @@ void ShapeMap::ozlemSpecial2(ShapeMap& buildings)
    pvecint removelist;
 
    size_t i;
-   for (auto shape: m_shapes) {
+   for (auto& shape: m_shapes) {
       Line& li = shape.second.m_region;
       int buildingid = (int) m_attributes.getValue(i,myrefcol);
       pvector<ValuePair> cuts;
@@ -3707,7 +3707,7 @@ void ShapeMap::ozlemSpecial3(ShapeMap& all)
    lookupcols.b = all.m_attributes.getColumnIndex("FeatureCode");
 
    int i = -1;
-   for (auto shape: m_shapes) {
+   for (auto& shape: m_shapes) {
       i++;
       Line& li = shape.second.m_region;
       pvector<ValuePair> cuts;
@@ -4014,7 +4014,7 @@ void ShapeMap::ozlemSpecial6() // ShapeMap& border)
    int delcol = m_attributes.insertColumn("Delete");
    int dupcol = m_attributes.insertColumn("Duplicate");
    int i = -1;
-   for (auto shape: m_shapes) {
+   for (auto& shape: m_shapes) {
       i++;
       bool duplicate = false;
       bool tag_delete = false;
@@ -4062,7 +4062,7 @@ void ShapeMap::ozlemSpecial7(ShapeMap& linemap)
    int linerefcol = m_attributes.insertColumn("Line Ref");
    
    int i = -1;
-   for (auto shape: m_shapes) {
+   for (auto& shape: m_shapes) {
       i++;
       Point2f p = shape.second.getPoint();
       int index = linemap.getClosestLine(p);
@@ -4076,7 +4076,7 @@ void ShapeMap::ozlemSpecial7(ShapeMap& linemap)
 std::vector<SimpleLine> ShapeMap::getAllShapesAsLines() {
     std::vector<SimpleLine> lines;
     std::map<int,SalaShape>& allShapes = getAllShapes();
-    for (auto refShape: allShapes) {
+    for (auto& refShape: allShapes) {
         SalaShape& shape = refShape.second;
         if (shape.isLine()) {
             lines.push_back(SimpleLine(shape.getLine()));
@@ -4098,7 +4098,7 @@ std::vector<std::pair<SimpleLine, PafColor>> ShapeMap::getAllLinesWithColour() {
     const AttributeTable &attributeTable = getAttributeTable();
     std::map<int,SalaShape>& allShapes = getAllShapes();
     int k = -1;
-    for (auto refShape: allShapes) {
+    for (auto& refShape: allShapes) {
         k++;
         SalaShape& shape = refShape.second;
         PafColor color(attributeTable.getDisplayColor(k));
@@ -4119,7 +4119,7 @@ std::map<std::vector<Point2f>, PafColor> ShapeMap::getAllPolygonsWithColour() {
     const AttributeTable &attributeTable = getAttributeTable();
     std::map<int,SalaShape>& allShapes = getAllShapes();
     int k = -1;
-    for (auto refShape: allShapes) {
+    for (auto& refShape: allShapes) {
         k++;
         SalaShape& shape = refShape.second;
         if (shape.isPolygon()) {

--- a/salalib/shapemap.h
+++ b/salalib/shapemap.h
@@ -215,7 +215,7 @@ protected:
    mutable bool m_bsp_tree;
    //
    pqmap<int,SalaShape> m_shapes;
-   pqmap<int,SalaObject> m_objects;   // THIS IS UNUSED! Meant for each object to have many shapes
+   std::map<int,SalaObject> m_objects;   // THIS IS UNUSED! Meant for each object to have many shapes
    //
    prefvec<SalaEvent> m_undobuffer;
    //

--- a/salalib/shapemap.h
+++ b/salalib/shapemap.h
@@ -26,6 +26,7 @@
 #include <string>
 #include "salalib/importtypedefs.h"
 #include "genlib/bsptree.h"
+#include "genlib/containerutils.h"
 #include <set>
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -214,7 +215,7 @@ protected:
    mutable BSPNode *m_bsp_root;
    mutable bool m_bsp_tree;
    //
-   pqmap<int,SalaShape> m_shapes;
+   std::map<int,SalaShape> m_shapes;
    std::map<int,SalaObject> m_objects;   // THIS IS UNUSED! Meant for each object to have many shapes
    //
    prefvec<SalaEvent> m_undobuffer;
@@ -248,10 +249,10 @@ public:
    // num shapes for this object (note, request by object rowid
    // -- on interrogation, this is what you will usually receive)
    const size_t getShapeCount(int rowid) const
-   { return m_shapes.value(rowid).size(); }
+   { return depthmapX::getMapAtIndex(m_shapes, rowid)->second.size(); }
    //
    int getIndex(int rowid) const
-   { return m_shapes.key(rowid); }
+   { return depthmapX::getMapAtIndex(m_shapes, rowid)->first; }
    //
    // add shape tools
    void makePolyPixels(int shaperef);
@@ -477,7 +478,7 @@ public:
    const PafColor getShapeColor() const
    { return m_attributes.getDisplayColor(m_display_shapes[m_current]); }
    bool getShapeSelected() const
-   { return m_shapes[m_display_shapes[m_current]].m_selected; }
+   { return depthmapX::getMapAtIndex(m_shapes, m_display_shapes[m_current])->second.m_selected; }
    //
    double getLocationValue(const Point2f& point) const;
 
@@ -491,9 +492,9 @@ public:
    { return __max(m_region.width(), m_region.height()) / (10 * log((double)10+m_shapes.size())); }
    //
    // dangerous: accessor for the shapes themselves:
-   const pqmap<int,SalaShape>& getAllShapes() const
+   const std::map<int,SalaShape>& getAllShapes() const
    { return m_shapes; }
-   pqmap<int,SalaShape>& getAllShapes()
+   std::map<int,SalaShape>& getAllShapes()
    { return m_shapes; }
    // required for PixelBase, have to implement your own version of pixelate
    PixelRef pixelate( const Point2f& p, bool constrain = true, int = 1) const;

--- a/salalib/shapemap.h
+++ b/salalib/shapemap.h
@@ -256,7 +256,7 @@ public:
    //
    // add shape tools
    void makePolyPixels(int shaperef);
-   void shapePixelBorder(pmap<int,int>& relations, int shaperef, int side, PixelRef currpix, PixelRef minpix, bool first);
+   void shapePixelBorder(std::map<int,int>& relations, int shaperef, int side, PixelRef currpix, PixelRef minpix, bool first);
    // remove shape tools
    void removePolyPixels(int shaperef);
    //
@@ -309,7 +309,7 @@ public:
    Point2f pointOffset(const PointMap& pointmap, int currpix, int side);
    int moveDir(int side);
    //
-   void pointPixelBorder(const PointMap& pointmap, pmap<int,int>& relations, SalaShape& shape, int side, PixelRef currpix, PixelRef minpix, bool first);
+   void pointPixelBorder(const PointMap& pointmap, std::map<int, int> &relations, SalaShape& shape, int side, PixelRef currpix, PixelRef minpix, bool first);
    // quick find of topmost poly from a point (bit too inaccurate!)
    int quickPointInPoly(const Point2f& p) const;
    // slower point in topmost poly test:

--- a/salalib/spacepix.cpp
+++ b/salalib/spacepix.cpp
@@ -536,7 +536,7 @@ void SpacePixel::reinitLines(double density)
    }
 
    // now re-add the lines:
-   for (auto line: m_lines) {
+   for (auto& line: m_lines) {
       PixelRefVector list = pixelateLine( line.second.line );
       for (size_t j = 0; j < list.size(); j++) {
          // note: m_pixel_lines will be reordered by sortPixelLines
@@ -1001,7 +1001,7 @@ bool SpacePixel::read( istream& stream, int version )
 
    // now load into structure:
    int n = -1;
-   for (auto line: m_lines) {
+   for (auto& line: m_lines) {
       n++;
 
       PixelRefVector list = pixelateLine( line.second.line );

--- a/salalib/spacepix.h
+++ b/salalib/spacepix.h
@@ -28,6 +28,7 @@
 #include "salalib/pixelref.h"
 #include "salalib/pafcolor.h"
 #include "genlib/paftl.h"
+#include <map>
 
 class SalaShape;
 
@@ -125,7 +126,7 @@ protected:
 //   double m_pixel_width;
    //
    int m_ref;
-   pmap<int,LineTest> m_lines;
+   std::map<int,LineTest> m_lines;
    //
    // for screen drawing
    mutable int *m_display_lines;
@@ -179,7 +180,7 @@ public:
    QtRegion& getRegion() const
       { return (QtRegion&) m_region; }
    //
-   const pmap<int,LineTest>& getAllLines() const // Danger! Use solely to look at the raw line data
+   const std::map<int,LineTest>& getAllLines() const // Danger! Use solely to look at the raw line data
       { return m_lines; }
    //
    // For easy layer manipulation:

--- a/salalib/sparksieve2.cpp
+++ b/salalib/sparksieve2.cpp
@@ -52,7 +52,7 @@ bool sparkSieve2::testblock( const Point2f& point, const std::map<int,Line>& lin
       return true;
    }
 
-   for (auto line: lines)
+   for (auto& line: lines)
    {
       // Note: must check regions intersect before using this intersect_line test -- see notes on intersect_line
       if (intersect_region(l,line.second,tolerance) && intersect_line(l,line.second,tolerance)) {
@@ -67,7 +67,7 @@ bool sparkSieve2::testblock( const Point2f& point, const std::map<int,Line>& lin
 
 void sparkSieve2::block( const std::map<int,Line>& lines, int q )
 {
-   for (auto line: lines) {
+   for (auto& line: lines) {
       double a = tanify(line.second.start(), q);
       double b = tanify(line.second.end(), q);
 

--- a/salalib/tigerp.cpp
+++ b/salalib/tigerp.cpp
@@ -57,9 +57,10 @@ void TigerMap::parse(const std::vector<string>& fileset, Communicator *comm)
             // grab major code:
             std::string code = line.substr(55,2);
             if (code[0] == 'A' || code[0] == 'B') {
-               size_t index = searchindex(code);
-               if (index == paftl::npos) {
-                  index = add(code,TigerCategory(),paftl::ADD_HERE);
+               auto iter = find(code);
+               if (iter == end()) {
+                  insert(std::make_pair(code,TigerCategory()));
+                  iter = find(code);
                }
                int long1 = stoi(line.substr(190,10));
                int lat1  = stoi(line.substr(200,9));
@@ -68,8 +69,8 @@ void TigerMap::parse(const std::vector<string>& fileset, Communicator *comm)
                Point2f p1(double(long1)/1e6,double(lat1)/1e6);
                Point2f p2(double(long2)/1e6,double(lat2)/1e6);
                Line li(p1,p2);
-               value(index).push_back(TigerChain());
-               value(index).tail().push_back(li);
+               iter->second.push_back(TigerChain());
+               iter->second.tail().push_back(li);
                if (!m_init) {
                   m_region = li;
                   m_init = true;

--- a/salalib/tigerp.h
+++ b/salalib/tigerp.h
@@ -38,7 +38,7 @@ public:
    TigerCategory() {;}
 };
 
-class TigerMap : public pqmap<std::string,TigerCategory>
+class TigerMap : public std::map<std::string,TigerCategory>
 {
 protected:
    QtRegion m_region;


### PR DESCRIPTION
Remove various unused and deprecated functions:
- ShapeGraph::cutLines

Replace all instances of pqmap with std::map except the ones in attributes.h/.cpp
Replace many instances of pmap with std::map