### PR TITLE
Remove shaperef counter

### DIFF
--- a/depthmapX/depthmapView.cpp
+++ b/depthmapX/depthmapView.cpp
@@ -1026,7 +1026,7 @@ void QDepthmapView::mouseReleaseEvent(QMouseEvent *e)
 			 update();
 			 // if it's the first part, just make it a line:
 			 if (m_poly_points == 0) {
-                m_pDoc.m_meta_graph->polyBegin(Line(m_line.t_start(),location));
+                m_currentlyEditingShapeRef = m_pDoc.m_meta_graph->polyBegin(Line(m_line.t_start(),location));
 				m_poly_start = m_line.t_start();
 				m_poly_points += 2;
 				m_mouse_mode |= DRAWLINE;
@@ -1036,11 +1036,12 @@ void QDepthmapView::mouseReleaseEvent(QMouseEvent *e)
 			 }
 			 else if (m_poly_points > 2 && PixelDist(point,PhysicalUnits(m_poly_start)) < 6) {
 				// check to see if it's back to the original start point, if so, close off
-                m_pDoc.m_meta_graph->polyClose();
+                m_pDoc.m_meta_graph->polyClose(m_currentlyEditingShapeRef);
 				m_poly_points = 0;
+                m_currentlyEditingShapeRef = -1;
 			 }
 			 else {
-                m_pDoc.m_meta_graph->polyAppend(location);
+                m_pDoc.m_meta_graph->polyAppend(m_currentlyEditingShapeRef, location);
 				m_poly_points += 1;
 				m_mouse_mode |= DRAWLINE;
 				m_line = Line(location, location);
@@ -1118,7 +1119,8 @@ void QDepthmapView::mouseReleaseEvent(QMouseEvent *e)
 				m_mouse_mode &= ~DRAWLINE;
 				if (m_mouse_mode & POLYGONTOOL && m_poly_points > 0) {
 					m_poly_points = 0;
-                    m_pDoc.m_meta_graph->polyCancel();
+                    m_currentlyEditingShapeRef = -1;
+                    m_pDoc.m_meta_graph->polyCancel(m_currentlyEditingShapeRef);
                     m_pDoc.SetRedrawFlag(QGraphDoc::VIEW_ALL, QGraphDoc::REDRAW_GRAPH, QGraphDoc::NEW_DATA );
 				}
 				else {

--- a/depthmapX/depthmapView.h
+++ b/depthmapX/depthmapView.h
@@ -155,6 +155,8 @@ private:
    prefvec<Point2f> m_point_handles;
    int m_active_point_handle;
 
+   int m_currentlyEditingShapeRef = -1;
+
    // polygon drawing utilities
    Point2f m_poly_start;
    int m_poly_points;

--- a/depthmapX/glview.cpp
+++ b/depthmapX/glview.cpp
@@ -340,19 +340,20 @@ void GLView::mouseReleaseEvent(QMouseEvent *event)
         case MOUSE_MODE_POLYGON_TOOL | MOUSE_MODE_SECOND_POINT:
         {
             if (m_polyPoints == 0) {
-               m_pDoc.m_meta_graph->polyBegin(Line(m_tempFirstPoint,worldPoint));
+               m_currentlyEditingShapeRef = m_pDoc.m_meta_graph->polyBegin(Line(m_tempFirstPoint,worldPoint));
                m_polyStart = m_tempFirstPoint;
                m_tempFirstPoint = m_tempSecondPoint;
                m_polyPoints += 2;
             }
             else if (m_polyPoints > 2 && PixelDist(mousePoint, getScreenPoint(m_polyStart)) < 6) {
                // check to see if it's back to the original start point, if so, close off
-               m_pDoc.m_meta_graph->polyClose();
+               m_pDoc.m_meta_graph->polyClose(m_currentlyEditingShapeRef);
                m_polyPoints = 0;
+               m_currentlyEditingShapeRef = -1;
                m_mouseMode = MOUSE_MODE_POLYGON_TOOL;
             }
             else {
-               m_pDoc.m_meta_graph->polyAppend(worldPoint);
+               m_pDoc.m_meta_graph->polyAppend(m_currentlyEditingShapeRef, worldPoint);
                m_tempFirstPoint = m_tempSecondPoint;
                m_polyPoints += 1;
             }

--- a/depthmapX/glview.h
+++ b/depthmapX/glview.h
@@ -153,6 +153,8 @@ private:
     Point2f m_tempFirstPoint;
     Point2f m_tempSecondPoint;
 
+    int m_currentlyEditingShapeRef = -1;
+
     Point2f m_polyStart;
     int m_polyPoints = 0;
 

--- a/salalib/axialmap.cpp
+++ b/salalib/axialmap.cpp
@@ -1408,7 +1408,7 @@ int ShapeGraphs::convertDataToAxial(Communicator *comm, const std::string& name,
 
    usermap.init(lines.size(),region);  // used to be double density
    for (size_t k = 0; k < lines.size(); k++) {
-      usermap.makeLineShape(lines[k]);
+      usermap.makeLineShapeWithRef(lines[k], keys[k]);
    }
 
    // n.b. make connections also initialises attributes
@@ -1720,7 +1720,7 @@ int ShapeGraphs::convertDataToSegment(Communicator *comm, const std::string& nam
 
    usermap.init(lines.size(),region);
    for (size_t k = 0; k < lines.size(); k++) {
-      usermap.makeLineShape(lines[k]);
+      usermap.makeLineShapeWithRef(lines[k], keys[k]);
    }
 
    // start to be a little bit more efficient about memory now we are hitting the limits

--- a/salalib/axialmap.cpp
+++ b/salalib/axialmap.cpp
@@ -123,7 +123,7 @@ AxialVertex AxialPolygons::makeVertex(const AxialVertexKey& vertexkey, const Poi
    }
 
    // ADDED 4-Nov-04 -- In order to stop too many lines being generated, don't include
-   // points that do not change surface direction:  -- notice: will create problems with circles 
+   // points that do not change surface direction:  -- notice: will create problems with circles
    if (fabs(dot(a,b)) > 0.999) {
       return av;
    }
@@ -203,7 +203,7 @@ void AxialPolygons::init(prefvec<Line>& lines, const QtRegion& region)
    firstpass.makeSegmentMap(lines, connectionset, 1.0);
 
    // now we have a set of lines and a set of connections...
-   // ...for the second pass, a bit of retro fitting to my original code is 
+   // ...for the second pass, a bit of retro fitting to my original code is
    // required
    makeVertexPossibles(lines, connectionset);
 
@@ -382,7 +382,7 @@ AxialVertexKey AxialPolygons::seedVertex(const Point2f& seed)
             allboundaries |= 0x08; seedref.y = m_rows - 1;
          }
          if (allboundaries == 0x0f) {
-            return NoVertex; 
+            return NoVertex;
          }
       }
    }
@@ -688,7 +688,7 @@ bool ShapeGraphs::makeAllLineMap(Communicator *comm, SuperSpacePixel& superspace
                throw Communicator::CancelledException();
             }
             comm->CommPostMessage( Communicator::CURRENT_RECORD, count );
-         }         
+         }
       }
 
    }
@@ -728,13 +728,13 @@ bool ShapeGraphs::makeAllLineMap(Communicator *comm, SuperSpacePixel& superspace
 
    // create the all line map layer...
    m_all_line_map = addMap("All-Line Map", ShapeMap::ALLLINEMAP);
-   
+
    ShapeGraph& alllinemap = at(m_all_line_map);
    // make sure it's cleared fully
    alllinemap.clearAll();
-   
-/*  
-   // temp: 
+
+/*
+   // temp:
    alllinemap.initLines(m_polygons.m_lines.size(),m_polygons.m_region.bottom_left,m_polygons.m_region.top_right,2);
    for (int k = 0; k < m_polygons.m_lines.size(); k++) {
       alllinemap.makeLineShape(m_polygons.m_lines[k].line);
@@ -748,7 +748,7 @@ bool ShapeGraphs::makeAllLineMap(Communicator *comm, SuperSpacePixel& superspace
       axiallines[k].crop(region); // <- should be cropped anyway, but causing an error
       alllinemap.makeLineShape(axiallines[k]);
    }
-   
+
    // n.b. make connections also initialises attributes
    // -> don't know what this was for: alllinemap.sortBins(m_poly_connections);
    alllinemap.makeConnections(preaxialdata);
@@ -837,7 +837,7 @@ bool ShapeGraphs::makeFewestLineMap(Communicator *comm, bool replace_existing)
 
    // and a little more setting up: key vertex relationships
    prefvec<pvecint> keyvertexconns;
-   int *keyvertexcounts = new int [at(m_all_line_map).m_keyvertexcount]; 
+   int *keyvertexcounts = new int [at(m_all_line_map).m_keyvertexcount];
    for (int x = 0; x < at(m_all_line_map).m_keyvertexcount; x++) {
       keyvertexcounts[x] = 0;
    }
@@ -856,7 +856,7 @@ bool ShapeGraphs::makeFewestLineMap(Communicator *comm, bool replace_existing)
       }
    }
 
-   // ok, after this fairly tedious set up, we are ready to go... 
+   // ok, after this fairly tedious set up, we are ready to go...
    // note axradialcuts aren't required anymore...
 
    AxialMinimiser minimiser(at(m_all_line_map), ax_seg_cuts, radialsegs);
@@ -949,7 +949,7 @@ AxialMinimiser::AxialMinimiser(const ShapeGraph& alllinemap, pqmap<int,pvecint>&
 AxialMinimiser::~AxialMinimiser()
 {
    delete [] m_vital;
-   delete [] m_affected;   
+   delete [] m_affected;
    delete [] m_radialsegcounts;
    delete [] m_vps;
    delete [] m_removed;
@@ -1349,7 +1349,7 @@ int ShapeGraphs::convertDrawingToAxial(Communicator *comm, const std::string& na
    return mapref;
 }
 
-// create axial map directly from data maps 
+// create axial map directly from data maps
 // note that actually should be able to merge this code with the line layers, now both use similar code
 
 int ShapeGraphs::convertDataToAxial(Communicator *comm, const std::string& name, ShapeMap& shapemap, bool copydata)
@@ -1421,7 +1421,7 @@ int ShapeGraphs::convertDataToAxial(Communicator *comm, const std::string& name,
       AttributeTable& output = usermap.getAttributeTable();
       for (int i = 0; i < input.getColumnCount(); i++) {
          std::string colname = input.getColumnName(i);
-         for (size_t k = 1; output.getColumnIndex(colname) != -1; k++) 
+         for (size_t k = 1; output.getColumnIndex(colname) != -1; k++)
             colname = dXstring::formatString((int)k,input.getColumnName(i) + " %d");
          int outcol = output.insertColumn(colname);
          for (size_t j = 0; j < lines.size(); j++) {
@@ -1459,7 +1459,7 @@ int ShapeGraphs::convertDrawingToConvex(Communicator *comm, const std::string& n
    int mapref = addMap(name,ShapeMap::CONVEXMAP);
    ShapeGraph& usermap = tail();
    int conn_col = usermap.m_attributes.insertLockedColumn("Connectivity");
-   
+
    size_t count = 0;
    size_t i = 0;
    for (i = 0; i < superspacepix.size(); i++) {
@@ -1525,7 +1525,7 @@ int ShapeGraphs::convertDataToConvex(Communicator *comm, const std::string& name
       AttributeTable& output = usermap.getAttributeTable();
       for (int i = 0; i < input.getColumnCount(); i++) {
          std::string colname = input.getColumnName(i);
-         for (int k = 1; output.getColumnIndex(colname) != -1; k++) 
+         for (int k = 1; output.getColumnIndex(colname) != -1; k++)
             colname = dXstring::formatString(k,input.getColumnName(i) + " %d");
          int outcol = output.insertColumn(colname);
          for (size_t j = 0; j < lookup.size(); j++) {
@@ -1608,7 +1608,7 @@ int ShapeGraphs::convertDrawingToSegment(Communicator *comm, const std::string& 
    if (lines.size() == 0) {
       return -1;
    }
-   
+
    /*
    // No longer required for ShapeMaps version:
    if (!m_length) {
@@ -1740,7 +1740,7 @@ int ShapeGraphs::convertDataToSegment(Communicator *comm, const std::string& nam
       //
       for (int i = 0; i < input.getColumnCount(); i++) {
          std::string colname = input.getColumnName(i);
-         for (int k = 1; output.getColumnIndex(colname) != -1; k++) 
+         for (int k = 1; output.getColumnIndex(colname) != -1; k++)
             colname = dXstring::formatString(k,input.getColumnName(i) + " %d");
          int outcol = output.insertColumn(colname);
          for (size_t j = 0; j < lines.size(); j++) {
@@ -1911,7 +1911,7 @@ static std::string makeRadiusText(int radius_type, double radius)
 
 ShapeGraph::ShapeGraph(const std::string& name, int type) : ShapeMap(name,type)
 {
-   m_keyvertexcount = 0; 
+   m_keyvertexcount = 0;
    m_hasgraph = true;
 }
 
@@ -1986,7 +1986,7 @@ bool ShapeGraph::outputMifPolygons(ostream& miffile, ostream& midfile) const
    }
    AxialPolygons polygons;
    polygons.init(lines, m_region);
-   
+
    prefvec<pqvector<Point2f>> newpolygons;
    polygons.makePolygons(newpolygons);
 
@@ -2130,7 +2130,7 @@ void ShapeGraph::makeDivisions(const prefvec<PolyConnector>& polyconnections, co
                throw Communicator::CancelledException();
             }
             comm->CommPostMessage( Communicator::CURRENT_RECORD, i );
-         }         
+         }
       }
    }
 }
@@ -2510,7 +2510,7 @@ bool ShapeGraph::integrate(Communicator *comm, const pvecint& radius_list, bool 
                   depthcounts.tail() += 1;
                }
             }
-            if (!choice) 
+            if (!choice)
                foundlist.a().pop_back();
             else
                foundlist.a().remove_at(pos);
@@ -2663,7 +2663,7 @@ bool ShapeGraph::integrate(Communicator *comm, const pvecint& radius_list, bool 
                throw Communicator::CancelledException();
             }
             comm->CommPostMessage( Communicator::CURRENT_RECORD, i );
-         }         
+         }
       }
    }
    delete [] covered;
@@ -3058,14 +3058,14 @@ void ShapeGraph::makeNewSegMap()
 
 // Method 2: Making a segment map (in two stages)
 
-// One: take the original axial map and split it up 
+// One: take the original axial map and split it up
 // (note: you need to start from an axial map,
 //  but the map could have been created from a road-centre-line
-//  graph or equivalent -- reason is that you might want to 
+//  graph or equivalent -- reason is that you might want to
 //  preserve unlinks in your angular mapping)
 
 // A "linetest" is used in order to use the test component to
-// identify the original axial line this line segment is 
+// identify the original axial line this line segment is
 // associated with
 
 void ShapeGraph::makeSegmentMap(prefvec<Line>& lineset, prefvec<Connector>& connectionset, double stubremoval)
@@ -3099,7 +3099,7 @@ void ShapeGraph::makeSegmentMap(prefvec<Line>& lineset, prefvec<Connector>& conn
       Point2f lastpoint = line.start();
       int seg_a = -1, seg_b = -1;
       double neardist;
-      // TOLERANCE_C is introduced as of 01.08.2008 although it is a fix to a bug first 
+      // TOLERANCE_C is introduced as of 01.08.2008 although it is a fix to a bug first
       // found in July 2006.  It has been set "high" deliberately (1e-6 = a millionth of the line height / width)
       // in order to catch small errors made by operators or floating point errors in other systems
       // when drawing, for example, three axial lines intersecting
@@ -3338,7 +3338,7 @@ bool ShapeGraph::analyseAngular(Communicator *comm, const pvecdouble& radius_lis
       std::string total_col_text = std::string("Angular Total Depth") + radius_text;
       m_attributes.insertColumn(total_col_text.c_str());
    }
-   
+
    for (r = 0; r < radius.size(); r++) {
       std::string radius_text = makeRadiusText(Options::RADIUS_ANGULAR,radius[r]);
       std::string depth_col_text = std::string("Angular Mean Depth") + radius_text;
@@ -3434,7 +3434,7 @@ bool ShapeGraph::analyseAngular(Communicator *comm, const pvecdouble& radius_lis
                throw Communicator::CancelledException();
             }
             comm->CommPostMessage( Communicator::CURRENT_RECORD, i );
-         }         
+         }
       }
    }
    delete [] covered;
@@ -3501,11 +3501,11 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
    //EF routeweight*
    std::string routeweight_col_text;
    if (routeweight_col != -1) {
-	   //we normalise the column values between 0 and 1 and reverse it so that high values can be treated as a 'low cost' - similar to the angular cost
-	  double max_value = m_attributes.getMaxValue(routeweight_col);
+       //we normalise the column values between 0 and 1 and reverse it so that high values can be treated as a 'low cost' - similar to the angular cost
+      double max_value = m_attributes.getMaxValue(routeweight_col);
      routeweight_col_text = m_attributes.getColumnName(routeweight_col);
-	  for (size_t i = 0; i < m_connectors.size(); i++) {
-		 routeweights.push_back(1.0-(m_attributes.getValue(i, routeweight_col)/max_value)); //scale and revert!
+      for (size_t i = 0; i < m_connectors.size(); i++) {
+         routeweights.push_back(1.0-(m_attributes.getValue(i, routeweight_col)/max_value)); //scale and revert!
       }
    }
    else { // Normal run // TV
@@ -3539,121 +3539,121 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
    for (r = 0; r < radius_unconverted.size(); r++) {
       std::string radius_text = makeRadiusText(radius_type, radius_unconverted[r]);
       int choice_col = -1, n_choice_col = -1, w_choice_col = -1, nw_choice_col = -1;
-      if (choice) {	
-			//EF routeweight *
-			if (routeweight_col != -1) {
+      if (choice) {
+            //EF routeweight *
+            if (routeweight_col != -1) {
                 std::string choice_col_text = tulip_text + " Choice [Route weight by " + routeweight_col_text + "]"+ radius_text;
-				m_attributes.insertColumn(choice_col_text.c_str());
-				if (weighting_col != -1) {					
+                m_attributes.insertColumn(choice_col_text.c_str());
+                if (weighting_col != -1) {
                     std::string w_choice_col_text = tulip_text + " Choice [[Route weight by " + routeweight_col_text + "][" + weighting_col_text + " Wgt]]" + radius_text;
-					
-					m_attributes.insertColumn(w_choice_col_text.c_str());
-				}
-				//EFEF*
-				if (weighting_col2 != -1) {
+
+                    m_attributes.insertColumn(w_choice_col_text.c_str());
+                }
+                //EFEF*
+                if (weighting_col2 != -1) {
                     std::string w_choice_col_text2 = tulip_text + " Choice [[Route weight by " + routeweight_col_text + "][" + weighting_col_text + "-" + weighting_col_text2 + " Wgt]]" + radius_text;
-					
-					m_attributes.insertColumn(w_choice_col_text2.c_str());
-				}
-				//*EFEF
-			}
-			//*EF routeweight
+
+                    m_attributes.insertColumn(w_choice_col_text2.c_str());
+                }
+                //*EFEF
+            }
+            //*EF routeweight
             else { // Normal run // TV
                 std::string choice_col_text = tulip_text + " Choice" + radius_text;
-				m_attributes.insertColumn(choice_col_text.c_str());
-				if (weighting_col != -1) {
+                m_attributes.insertColumn(choice_col_text.c_str());
+                if (weighting_col != -1) {
                     std::string w_choice_col_text = tulip_text + " Choice [" + weighting_col_text + " Wgt]" + radius_text;
-					m_attributes.insertColumn(w_choice_col_text.c_str());
-				}
-				//EFEF*
-				if (weighting_col2 != -1) {
+                    m_attributes.insertColumn(w_choice_col_text.c_str());
+                }
+                //EFEF*
+                if (weighting_col2 != -1) {
                     std::string w_choice_col_text2 = tulip_text + " Choice [" + weighting_col_text + "-" + weighting_col_text2 + " Wgt]" + radius_text;
-					m_attributes.insertColumn(w_choice_col_text2.c_str());
-				}
-				//*EFEF
-			}
+                    m_attributes.insertColumn(w_choice_col_text2.c_str());
+                }
+                //*EFEF
+            }
       }
 
-		//EF routeweight *
-		if (routeweight_col != -1) {
+        //EF routeweight *
+        if (routeweight_col != -1) {
          std::string integ_col_text = tulip_text + " Integration [Route weight by " + routeweight_col_text + "]"+ radius_text; // <- note, the fact this is a tulip is unnecessary
             std::string w_integ_col_text = tulip_text + " Integration [[Route weight by " + routeweight_col_text + "][" + weighting_col_text + " Wgt]]" + radius_text;
 
          std::string count_col_text = tulip_text + " Node Count [Route weight by " + routeweight_col_text + "]"+ radius_text; // <- note, the fact this is a tulip is unnecessary
             std::string td_col_text = tulip_text + " Total Depth [Route weight by " + routeweight_col_text + "]"+ radius_text; // <- note, the fact this is a tulip is unnecessary
-			// '[' comes after 'R' in ASCII, so this column will come after Mean Depth R...
+            // '[' comes after 'R' in ASCII, so this column will come after Mean Depth R...
             std::string w_td_text = tulip_text + " Total Depth [[Route weight by " + routeweight_col_text + "][" + weighting_col_text + " Wgt]]" + radius_text;
             std::string total_weight_text = tulip_text + " Total " + weighting_col_text + " [Route weight by " + routeweight_col_text + "]" +radius_text;
 
          m_attributes.insertColumn(integ_col_text.c_str());
-			m_attributes.insertColumn(count_col_text.c_str());
-			m_attributes.insertColumn(td_col_text.c_str());
-			if (weighting_col != -1) {
+            m_attributes.insertColumn(count_col_text.c_str());
+            m_attributes.insertColumn(td_col_text.c_str());
+            if (weighting_col != -1) {
             m_attributes.insertColumn(w_integ_col_text.c_str());
-				m_attributes.insertColumn(w_td_text.c_str());         
-				m_attributes.insertColumn(total_weight_text.c_str());
-			}
-		}
-		//*EF routeweight
+                m_attributes.insertColumn(w_td_text.c_str());
+                m_attributes.insertColumn(total_weight_text.c_str());
+            }
+        }
+        //*EF routeweight
         else { // Normal run // TV
             std::string integ_col_text = tulip_text + " Integration" + radius_text; // <- note, the fact this is a tulip is unnecessary
             std::string w_integ_col_text = tulip_text + " Integration [" + weighting_col_text + " Wgt]" + radius_text;
 
             std::string count_col_text = tulip_text + " Node Count" + radius_text; // <- note, the fact this is a tulip is unnecessary
             std::string td_col_text = tulip_text + " Total Depth" + radius_text; // <- note, the fact this is a tulip is unnecessary
-			// '[' comes after 'R' in ASCII, so this column will come after Mean Depth R...
+            // '[' comes after 'R' in ASCII, so this column will come after Mean Depth R...
             std::string w_td_text = tulip_text + " Total Depth [" + weighting_col_text + " Wgt]" + radius_text;
             std::string total_weight_text = tulip_text + " Total " + weighting_col_text + radius_text;
 
          m_attributes.insertColumn(integ_col_text.c_str());
-			m_attributes.insertColumn(count_col_text.c_str());
-			m_attributes.insertColumn(td_col_text.c_str());
-			if (weighting_col != -1) {         
+            m_attributes.insertColumn(count_col_text.c_str());
+            m_attributes.insertColumn(td_col_text.c_str());
+            if (weighting_col != -1) {
             m_attributes.insertColumn(w_integ_col_text.c_str());
-				m_attributes.insertColumn(w_td_text.c_str());         
-				m_attributes.insertColumn(total_weight_text.c_str());
-			}
-		}
+                m_attributes.insertColumn(w_td_text.c_str());
+                m_attributes.insertColumn(total_weight_text.c_str());
+            }
+        }
    }
    pvecint choice_col, w_choice_col, w_choice_col2, count_col, integ_col, w_integ_col, td_col, w_td_col, total_weight_col;
    // then look them up! eek....
    for (r = 0; r < radius_unconverted.size(); r++) {
       std::string radius_text = makeRadiusText(radius_type, radius_unconverted[r]);
       if (choice) {
-			//EF routeweight *
-			if (routeweight_col != -1) {
+            //EF routeweight *
+            if (routeweight_col != -1) {
                 std::string choice_col_text = tulip_text + " Choice [Route weight by " + routeweight_col_text + "]"+ radius_text;
-				choice_col.push_back(m_attributes.getColumnIndex(choice_col_text.c_str()));
-				if (weighting_col != -1) {
+                choice_col.push_back(m_attributes.getColumnIndex(choice_col_text.c_str()));
+                if (weighting_col != -1) {
                     std::string w_choice_col_text = tulip_text + " Choice [[Route weight by " + routeweight_col_text + "][" + weighting_col_text + " Wgt]]" + radius_text;
-					w_choice_col.push_back(m_attributes.getColumnIndex(w_choice_col_text.c_str()));
-				}
-				//EFEF*
-				if (weighting_col2 != -1) {
+                    w_choice_col.push_back(m_attributes.getColumnIndex(w_choice_col_text.c_str()));
+                }
+                //EFEF*
+                if (weighting_col2 != -1) {
                     std::string w_choice_col_text2 = tulip_text + " Choice [[Route weight by " + routeweight_col_text + "][" + weighting_col_text + "-" + weighting_col_text2 + " Wgt]]" + radius_text;
-					w_choice_col2.push_back(m_attributes.getColumnIndex(w_choice_col_text2.c_str()));
-				}
-				//*EFEF
-			}
-			//* EF routeweight
+                    w_choice_col2.push_back(m_attributes.getColumnIndex(w_choice_col_text2.c_str()));
+                }
+                //*EFEF
+            }
+            //* EF routeweight
             else { // Normal run // TV
                 std::string choice_col_text = tulip_text + " Choice" + radius_text;
-				choice_col.push_back(m_attributes.getColumnIndex(choice_col_text.c_str()));
-				if (weighting_col != -1) {
+                choice_col.push_back(m_attributes.getColumnIndex(choice_col_text.c_str()));
+                if (weighting_col != -1) {
                     std::string w_choice_col_text = tulip_text + " Choice [" + weighting_col_text + " Wgt]" + radius_text;
-					w_choice_col.push_back(m_attributes.getColumnIndex(w_choice_col_text.c_str()));
-				}
-				//EFEF*
-				if (weighting_col2 != -1) {
+                    w_choice_col.push_back(m_attributes.getColumnIndex(w_choice_col_text.c_str()));
+                }
+                //EFEF*
+                if (weighting_col2 != -1) {
                     std::string w_choice_col_text2 = tulip_text + " Choice [" + weighting_col_text + "-" + weighting_col_text2 + " Wgt]" + radius_text;
-					w_choice_col2.push_back(m_attributes.getColumnIndex(w_choice_col_text2.c_str()));
-				}
-				//*EFEF
-			}
-		 
+                    w_choice_col2.push_back(m_attributes.getColumnIndex(w_choice_col_text2.c_str()));
+                }
+                //*EFEF
+            }
+
       }
-		//EF routeweight *
-		if (routeweight_col != -1) {
+        //EF routeweight *
+        if (routeweight_col != -1) {
          std::string integ_col_text = tulip_text + " Integration [Route weight by " + routeweight_col_text + "]"+ radius_text; // <- note, the fact this is a tulip is unnecessary
             std::string w_integ_col_text = tulip_text + " Integration [[Route weight by " + routeweight_col_text + "][" + weighting_col_text + " Wgt]]" + radius_text;
 
@@ -3663,16 +3663,16 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
             std::string total_weight_col_text = tulip_text + " Total " + weighting_col_text + " [Route weight by " + routeweight_col_text + "]" +radius_text;
 
          integ_col.push_back(m_attributes.getColumnIndex(integ_col_text.c_str()));
-			count_col.push_back(m_attributes.getColumnIndex(count_col_text.c_str()));
-			td_col.push_back(m_attributes.getColumnIndex(td_col_text.c_str()));      
-			if (weighting_col != -1) {
-				// '[' comes after 'R' in ASCII, so this column will come after Mean Depth R...
+            count_col.push_back(m_attributes.getColumnIndex(count_col_text.c_str()));
+            td_col.push_back(m_attributes.getColumnIndex(td_col_text.c_str()));
+            if (weighting_col != -1) {
+                // '[' comes after 'R' in ASCII, so this column will come after Mean Depth R...
             w_integ_col.push_back(m_attributes.getColumnIndex(w_integ_col_text.c_str()));
-				w_td_col.push_back(m_attributes.getColumnIndex(w_td_text.c_str()));
-				total_weight_col.push_back(m_attributes.getColumnIndex(total_weight_col_text.c_str()));
-			}
-		}
-		//* EF routeweight
+                w_td_col.push_back(m_attributes.getColumnIndex(w_td_text.c_str()));
+                total_weight_col.push_back(m_attributes.getColumnIndex(total_weight_col_text.c_str()));
+            }
+        }
+        //* EF routeweight
         else { // Normal run // TV
             std::string integ_col_text = tulip_text + " Integration" + radius_text; // <- note, the fact this is a tulip is unnecessary
             std::string w_integ_col_text = tulip_text + " Integration [" + weighting_col_text + " Wgt]" + radius_text;
@@ -3681,17 +3681,17 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
             std::string td_col_text = tulip_text + " Total Depth" + radius_text; // <- note, the fact this is a tulip is unnecessary
             std::string w_td_text = tulip_text + " Total Depth [" + weighting_col_text + " Wgt]" + radius_text;
             std::string total_weight_col_text = tulip_text + " Total " + weighting_col_text + radius_text;
-      
+
          integ_col.push_back(m_attributes.getColumnIndex(integ_col_text.c_str()));
-			count_col.push_back(m_attributes.getColumnIndex(count_col_text.c_str()));
-			td_col.push_back(m_attributes.getColumnIndex(td_col_text.c_str()));      
-			if (weighting_col != -1) {
-				// '[' comes after 'R' in ASCII, so this column will come after Mean Depth R...
+            count_col.push_back(m_attributes.getColumnIndex(count_col_text.c_str()));
+            td_col.push_back(m_attributes.getColumnIndex(td_col_text.c_str()));
+            if (weighting_col != -1) {
+                // '[' comes after 'R' in ASCII, so this column will come after Mean Depth R...
             w_integ_col.push_back(m_attributes.getColumnIndex(w_integ_col_text.c_str()));
-				w_td_col.push_back(m_attributes.getColumnIndex(w_td_text.c_str()));
-				total_weight_col.push_back(m_attributes.getColumnIndex(total_weight_col_text.c_str()));
-			}
-		}
+                w_td_col.push_back(m_attributes.getColumnIndex(w_td_text.c_str()));
+                total_weight_col.push_back(m_attributes.getColumnIndex(total_weight_col_text.c_str()));
+            }
+        }
    }
 
    tulip_bins /= 2;  // <- actually use semicircle of tulip bins
@@ -3738,7 +3738,7 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
    for (size_t rowid = 0; rowid < m_connectors.size(); rowid++) {
 
       if (selection_only) {
-         // could use m_selection_set.searchindex(rowid) to find 
+         // could use m_selection_set.searchindex(rowid) to find
          // if this row is selected as m_selection_set is ordered for axial and segment maps, etc
          // BUT, actually quicker to check the tag in the attributes that shows it's selected
          if (!m_attributes.isSelected(rowid)) {
@@ -3760,9 +3760,9 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
 
       double rootseglength = m_attributes.getValue(rowid,length_col);
       double rootweight = (weighting_col != -1) ? weights[rowid] : 0.0;
-		//EFEF
-		double rootweight2 = (weighting_col2 != -1) ? weights2[rowid] : 0.0;
-		//EFEF
+        //EFEF
+        double rootweight2 = (weighting_col2 != -1) ? weights2[rowid] : 0.0;
+        //EFEF
 
       // setup: direction 0 (both ways), segment i, previous -1, segdepth (step depth) 0, metricdepth 0.5 * rootseglength, bin 0
       bins[0].add(SegmentData(0,rowid,SegmentRef(),0,0.5*rootseglength,radiusmask));
@@ -3821,17 +3821,17 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
                   rbin = rbinbase;
                   SegmentRef conn = line.m_forward_segconns.key(k);
                   if ((uncovered[conn.ref][(conn.dir == 1 ? 0 : 1)] & coverage) != 0) {
-							//EF routeweight*
-							if (routeweight_col != -1) {  //EF here we do the weighting of the angular cost by the weight of the next segment
-													//note that the content of the routeweights array is scaled between 0 and 1 and is reversed 
-													// such that: = 1.0-(m_attributes.getValue(i, routeweight_col)/max_value)
-								extradepth = (int) floor(line.m_forward_segconns.value(k) * tulip_bins * 0.5 * routeweights[conn.ref]);					 
-							}
-							//*EF routeweight
-							else {
-								extradepth = (int) floor(line.m_forward_segconns.value(k) * tulip_bins * 0.5);
-							}
-							seglength = lengths[conn.ref];
+                            //EF routeweight*
+                            if (routeweight_col != -1) {  //EF here we do the weighting of the angular cost by the weight of the next segment
+                                                    //note that the content of the routeweights array is scaled between 0 and 1 and is reversed
+                                                    // such that: = 1.0-(m_attributes.getValue(i, routeweight_col)/max_value)
+                                extradepth = (int) floor(line.m_forward_segconns.value(k) * tulip_bins * 0.5 * routeweights[conn.ref]);
+                            }
+                            //*EF routeweight
+                            else {
+                                extradepth = (int) floor(line.m_forward_segconns.value(k) * tulip_bins * 0.5);
+                            }
+                            seglength = lengths[conn.ref];
                      switch (radius_type) {
                      case Options::RADIUS_ANGULAR:
                         while (rbin != radiussize && radius[rbin] != -1 && depthlevel+extradepth > (int) radius[rbin]) {
@@ -3843,7 +3843,7 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
                            rbin++;
                         }
                         break;
-                     case Options::RADIUS_STEPS: 
+                     case Options::RADIUS_STEPS:
                         if (rbin != radiussize && radius[rbin] != -1 && lineindex.segdepth >= (int) radius[rbin]) {
                            rbin++;
                         }
@@ -3862,16 +3862,16 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
                   rbin = rbinbase;
                   SegmentRef conn = line.m_back_segconns.key(k);
                   if ((uncovered[conn.ref][(conn.dir == 1 ? 0 : 1)] & coverage) != 0) {
-							//EF routeweight*
-							if (routeweight_col != -1) {  //EF here we do the weighting of the angular cost by the weight of the next segment
-													//note that the content of the routeweights array is scaled between 0 and 1 and is reversed 
-													// such that: = 1.0-(m_attributes.getValue(i, routeweight_col)/max_value)
-								extradepth = (int) floor(line.m_back_segconns.value(k) * tulip_bins * 0.5 * routeweights[conn.ref]);					 
-							}
-							//*EF routeweight
-							else {
-								extradepth = (int) floor(line.m_back_segconns.value(k) * tulip_bins * 0.5);
-							}
+                            //EF routeweight*
+                            if (routeweight_col != -1) {  //EF here we do the weighting of the angular cost by the weight of the next segment
+                                                    //note that the content of the routeweights array is scaled between 0 and 1 and is reversed
+                                                    // such that: = 1.0-(m_attributes.getValue(i, routeweight_col)/max_value)
+                                extradepth = (int) floor(line.m_back_segconns.value(k) * tulip_bins * 0.5 * routeweights[conn.ref]);
+                            }
+                            //*EF routeweight
+                            else {
+                                extradepth = (int) floor(line.m_back_segconns.value(k) * tulip_bins * 0.5);
+                            }
                      seglength = lengths[conn.ref];
                      switch (radius_type) {
                      case Options::RADIUS_ANGULAR:
@@ -3884,7 +3884,7 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
                            rbin++;
                         }
                         break;
-                     case Options::RADIUS_STEPS: 
+                     case Options::RADIUS_STEPS:
                         if (rbin != radiussize && radius[rbin] != -1 && lineindex.segdepth >= (int) radius[rbin]) {
                            rbin++;
                         }
@@ -3907,7 +3907,7 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
          double curs_total_weight = 0.0, curs_total_weighted_depth = 0.0;
          size_t j;
          for (j = 0; j < m_connectors.size(); j++) {
-            // find dir according 
+            // find dir according
             bool m0 = ((uncovered[j][0] >> k) & 0x1) == 0;
             bool m1 = ((uncovered[j][1] >> k) & 0x1) == 0;
             if ((m0 | m1) != 0) {
@@ -3934,9 +3934,9 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
                   if (here.ref != rowid) {
                      int choicecount = 0;
                      double choiceweight = 0.0;
-							//EFEF*
-							double choiceweight2 = 0.0;
-							//*EFEF
+                            //EFEF*
+                            double choiceweight2 = 0.0;
+                            //*EFEF
                      while (here.ref != rowid) { // not rowid means not the current root for the path
                         int heredir = (here.dir == 1) ? 0 : 1;
                         // each node has the existing choicecount and choiceweight from previously encountered nodes added to it
@@ -3944,29 +3944,29 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
                         // nb, weighted values calculated anyway to save time on 'if'
                         audittrail[here.ref][k][heredir].weighted_choice += choiceweight;
                         //EFEF*
-								audittrail[here.ref][k][heredir].weighted_choice2 += choiceweight2;
-								//*EFEF
-								// if the node hasn't been encountered before, the choicecount and choiceweight is 
+                                audittrail[here.ref][k][heredir].weighted_choice2 += choiceweight2;
+                                //*EFEF
+                                // if the node hasn't been encountered before, the choicecount and choiceweight is
                         // incremented for all remaining nodes to be encountered on the backwards route from it
                         if (!audittrail[here.ref][k][heredir].choicecovered) {
                            // this node has not been encountered before: this adds the choicecount and weight for this
                            // node, and flags it as visited
                            choicecount++;
                            choiceweight += weights[here.ref] * rootweight;
-									//EFEF*
-									choiceweight2 += weights2[here.ref] * rootweight;//rootweight!
-									//*EFEF
+                                    //EFEF*
+                                    choiceweight2 += weights2[here.ref] * rootweight;//rootweight!
+                                    //*EFEF
 
                            audittrail[here.ref][k][heredir].choicecovered = true;
                            // note, for weighted choice, the start and end points have choice added to them:
                            if (weighting_col != -1) {
                               audittrail[here.ref][k][heredir].weighted_choice += (weights[here.ref] * rootweight) / 2.0;
-										//EFEF*
-										if (weighting_col2 != -1) {
-											audittrail[here.ref][k][heredir].weighted_choice2 += (weights2[here.ref] * rootweight) / 2.0;  //rootweight!
-										}
-										//*EFEF
-									}
+                                        //EFEF*
+                                        if (weighting_col2 != -1) {
+                                            audittrail[here.ref][k][heredir].weighted_choice2 += (weights2[here.ref] * rootweight) / 2.0;  //rootweight!
+                                        }
+                                        //*EFEF
+                                    }
                         }
                         here = audittrail[here.ref][k][heredir].previous;
                      }
@@ -3974,12 +3974,12 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
                      // (this is the summed weight for all starting nodes encountered in this path)
                      if (weighting_col != -1) {
                         audittrail[here.ref][k][(here.dir == 1) ? 0 : 1].weighted_choice += choiceweight / 2.0;
-								//EFEF*
-								if (weighting_col2 != -1) {
-									audittrail[here.ref][k][(here.dir == 1) ? 0 : 1].weighted_choice2 += choiceweight2 / 2.0;
-								}
-								//*EFEF
-							}
+                                //EFEF*
+                                if (weighting_col2 != -1) {
+                                    audittrail[here.ref][k][(here.dir == 1) ? 0 : 1].weighted_choice2 += choiceweight2 / 2.0;
+                                }
+                                //*EFEF
+                            }
                   }
                }
             }
@@ -4023,8 +4023,8 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
       if (comm) {
          if (qtimer( atime, 500 )) {
             if (comm->IsCancelled()) {
-   				// interactive is usual Depthmap: throw an exception if cancelled
-	   			if (interactive) {
+                // interactive is usual Depthmap: throw an exception if cancelled
+                if (interactive) {
                   for (size_t i = 0; i < m_connectors.size(); i++) {
                      for (size_t j = 0; j < size_t(radiussize); j++) {
                         delete [] audittrail[i][j];
@@ -4043,7 +4043,7 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
                }
             }
             comm->CommPostMessage( Communicator::CURRENT_RECORD, rowid );
-         }         
+         }
       }
    }
    if (choice) {
@@ -4054,12 +4054,12 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
             double total_choice = audittrail[rowid][r][0].choice + audittrail[rowid][r][1].choice;
             double total_weighted_choice = audittrail[rowid][r][0].weighted_choice + audittrail[rowid][r][1].weighted_choice;
             //EFEF*
-				double total_weighted_choice2 = audittrail[rowid][r][0].weighted_choice2 + audittrail[rowid][r][1].weighted_choice2;
-				//*EFEF
-			
-				// normalised choice now excluded for two reasons:
+                double total_weighted_choice2 = audittrail[rowid][r][0].weighted_choice2 + audittrail[rowid][r][1].weighted_choice2;
+                //*EFEF
+
+                // normalised choice now excluded for two reasons:
             // a) not useful measure, b) in parallel calculations, cannot be calculated at this stage
-            // n.b., it is possible through the front end: the new choice takes into account bidirectional routes, 
+            // n.b., it is possible through the front end: the new choice takes into account bidirectional routes,
             // so it should be normalised according to (n-1)(n-2) (maximum possible through routes) not (n-1)(n-2)/2
             // the relativised segment length weighted choice equation was (total_seg_length*total_seg_length-seg_length*seg_length)/2
             // again, drop the divide by 2 for the new implementation
@@ -4068,12 +4068,12 @@ int ShapeGraph::analyseTulip(Communicator *comm, int tulip_bins, bool choice, in
             m_attributes.setValue(rowid,choice_col[r],float(total_choice));
             if (weighting_col != -1) {
                m_attributes.setValue(rowid,w_choice_col[r],float(total_weighted_choice));
-					//EFEF*
-					if (weighting_col2 != -1) {
-						m_attributes.setValue(rowid,w_choice_col2[r],float(total_weighted_choice2));
-					}
-					//*EFEF
-				}
+                    //EFEF*
+                    if (weighting_col2 != -1) {
+                        m_attributes.setValue(rowid,w_choice_col2[r],float(total_weighted_choice2));
+                    }
+                    //*EFEF
+                }
          }
       }
    }
@@ -4136,7 +4136,7 @@ bool ShapeGraph::angularstepdepth(Communicator *comm)
       }
       SegmentData lineindex;
       if (bins[currentbin].size() > 1) {
-         // it is slightly slower to delete from an arbitrary place in the bin, 
+         // it is slightly slower to delete from an arbitrary place in the bin,
          // but it is necessary to use random paths to even out the number of times through equal paths
          int curr = pafrand() % bins[currentbin].size();
          lineindex = bins[currentbin][curr];

--- a/salalib/importutils.cpp
+++ b/salalib/importutils.cpp
@@ -149,7 +149,7 @@ namespace depthmapX {
     bool importTxt(ShapeMap &shapeMap, std::istream &stream, char delimiter = '\t') {
         Table table = csvToTable(stream, delimiter);
         std::vector<std::string> columns;
-        int xcol = -1, ycol = -1, x1col = -1, y1col = -1, x2col = -1, y2col = -1;
+        int xcol = -1, ycol = -1, x1col = -1, y1col = -1, x2col = -1, y2col = -1, refcol = -1;
         for(auto const& column: table) {
             if (column.first == "x" || column.first == "easting")
                 xcol = columns.size();
@@ -163,10 +163,31 @@ namespace depthmapX {
                 y1col = columns.size();
             else if (column.first == "y2")
                 y2col = columns.size();
+            else if (column.first == "Ref")
+                refcol = columns.size();
             columns.push_back(column.first);
         }
 
-        if (xcol != -1 && ycol != -1) {
+        if (xcol != -1 && ycol != -1 && refcol != -1) {
+            std::map<int, Point2f> points = extractPointsWithRefs(table[columns[xcol]], table[columns[ycol]], table[columns[refcol]]);
+            table.erase(table.find(columns[xcol]));
+            table.erase(table.find(columns[ycol]));
+            table.erase(table.find(columns[refcol]));
+
+            QtRegion region;
+
+            for(auto& point: points) {
+                if(region.atZero()) {
+                    region = point.second;
+                } else {
+                    region = runion(region, point.second);
+                }
+            }
+
+            shapeMap.init(points.size(),region);
+            shapeMap.importPointsWithRefs(points, table);
+
+        } else if (xcol != -1 && ycol != -1) {
             std::vector<Point2f> points = extractPoints(table[columns[xcol]], table[columns[ycol]]);
             table.erase(table.find(columns[xcol]));
             table.erase(table.find(columns[ycol]));
@@ -184,6 +205,30 @@ namespace depthmapX {
             shapeMap.init(points.size(),region);
             shapeMap.importPoints(points, table);
 
+        } else if (x1col != -1 && y1col != -1 && x2col != -1 && y2col != -1 && refcol != -1) {
+            std::map<int, Line> lines = extractLinesWithRef(table[columns[x1col]],
+                    table[columns[y1col]],
+                    table[columns[x2col]],
+                    table[columns[y2col]],
+                    table[columns[refcol]]);
+            table.erase(table.find(columns[x1col]));
+            table.erase(table.find(columns[y1col]));
+            table.erase(table.find(columns[x2col]));
+            table.erase(table.find(columns[y2col]));
+            table.erase(table.find(columns[refcol]));
+
+            QtRegion region;
+
+            for(auto& line: lines) {
+                if(region.atZero()) {
+                    region = line.second;
+                } else {
+                    region = runion(region, line.second);
+                }
+            }
+
+            shapeMap.init(lines.size(),region);
+            shapeMap.importLinesWithRefs(lines, table);
         } else if (x1col != -1 && y1col != -1 && x2col != -1 && y2col != -1) {
             std::vector<Line> lines = extractLines(table[columns[x1col]], table[columns[y1col]], table[columns[x2col]], table[columns[y2col]]);
             table.erase(table.find(columns[x1col]));
@@ -263,10 +308,29 @@ namespace depthmapX {
         return lines;
     }
 
+    std::map<int, Line> extractLinesWithRef(ColumnData &x1col, ColumnData &y1col, ColumnData &x2col, ColumnData &y2col, ColumnData &refcol) {
+        std::map<int, Line> lines;
+        for(size_t i = 0; i < x1col.size(); i++) {
+            double x1 = stod(x1col[i]);
+            double y1 = stod(y1col[i]);
+            double x2 = stod(x2col[i]);
+            double y2 = stod(y2col[i]);
+            double ref = stoi(refcol[i]);
+            lines.insert(std::make_pair(ref, Line(Point2f(x1, y1), Point2f(x2, y2))));
+        }
+        return lines;
+    }
     std::vector<Point2f> extractPoints(ColumnData &x, ColumnData &y) {
         std::vector<Point2f> points;
         for(size_t i = 0; i < x.size(); i++) {
             points.push_back(Point2f(stod(x[i]), stod(y[i])));
+        }
+        return points;
+    }
+    std::map<int, Point2f> extractPointsWithRefs(ColumnData &x, ColumnData &y, ColumnData &ref) {
+        std::map<int, Point2f> points;
+        for(size_t i = 0; i < x.size(); i++) {
+            points.insert(std::make_pair(stoi(ref[i]), Point2f(stod(x[i]), stod(y[i]))));
         }
         return points;
     }

--- a/salalib/importutils.cpp
+++ b/salalib/importutils.cpp
@@ -315,7 +315,7 @@ namespace depthmapX {
             double y1 = stod(y1col[i]);
             double x2 = stod(x2col[i]);
             double y2 = stod(y2col[i]);
-            double ref = stoi(refcol[i]);
+            int ref = stoi(refcol[i]);
             lines.insert(std::make_pair(ref, Line(Point2f(x1, y1), Point2f(x2, y2))));
         }
         return lines;

--- a/salalib/importutils.cpp
+++ b/salalib/importutils.cpp
@@ -262,6 +262,7 @@ namespace depthmapX {
         }
         return lines;
     }
+
     std::vector<Point2f> extractPoints(ColumnData &x, ColumnData &y) {
         std::vector<Point2f> points;
         for(size_t i = 0; i < x.size(); i++) {

--- a/salalib/importutils.h
+++ b/salalib/importutils.h
@@ -26,6 +26,8 @@ namespace depthmapX {
     bool importTxt(ShapeMap &shapeMap, istream &stream, char delimiter);
     depthmapX::Table csvToTable(istream &stream, char delimiter);
     std::vector<Line> extractLines(ColumnData &x1col, ColumnData &y1col, ColumnData &x2col, ColumnData &y2col);
+    std::map<int, Line> extractLinesWithRef(ColumnData &x1col, ColumnData &y1col, ColumnData &x2col, ColumnData &y2col, ColumnData &refcol);
     std::vector<Point2f> extractPoints(ColumnData &x, ColumnData &y);
+    std::map<int, Point2f> extractPointsWithRefs(ColumnData &x, ColumnData &y, ColumnData &ref);
     bool importDxfLayer(const DxfLayer &dxfLayer, ShapeMap &shapeMap);
 }

--- a/salalib/mgraph.cpp
+++ b/salalib/mgraph.cpp
@@ -419,40 +419,40 @@ bool MetaGraph::makeShape(const Line& line)
    return (map.makeLineShape(line,true) != -1);
 }
 
-bool MetaGraph::polyBegin(const Line& line)
+int MetaGraph::polyBegin(const Line& line)
 {
    if (!isEditableMap()) {
       return false;
    }
    ShapeMap& map = getEditableMap();
-   return (map.polyBegin(line) != -1);
+   return map.polyBegin(line);
 }
 
-bool MetaGraph::polyAppend(const Point2f& point)
+bool MetaGraph::polyAppend(int shape_ref, const Point2f& point)
 {
    if (!isEditableMap()) {
       return false;
    }
    ShapeMap& map = getEditableMap();
-   return map.polyAppend(point);
+   return map.polyAppend(shape_ref, point);
 }
 
-bool MetaGraph::polyClose() 
+bool MetaGraph::polyClose(int shape_ref)
 {
    if (!isEditableMap()) {
       return false;
    }
    ShapeMap& map = getEditableMap();
-   return map.polyClose();
+   return map.polyClose(shape_ref);
 }
 
-bool MetaGraph::polyCancel()
+bool MetaGraph::polyCancel(int shape_ref)
 {
    if (!isEditableMap()) {
       return false;
    }
    ShapeMap& map = getEditableMap();
-   return map.polyCancel();
+   return map.polyCancel(shape_ref);
 }
 
 bool MetaGraph::moveSelShape(const Line& line)

--- a/salalib/mgraph.cpp
+++ b/salalib/mgraph.cpp
@@ -422,7 +422,7 @@ bool MetaGraph::makeShape(const Line& line)
 int MetaGraph::polyBegin(const Line& line)
 {
    if (!isEditableMap()) {
-      return false;
+      return -1;
    }
    ShapeMap& map = getEditableMap();
    return map.polyBegin(line);

--- a/salalib/mgraph.h
+++ b/salalib/mgraph.h
@@ -133,10 +133,10 @@ public:
    bool makeShape(const Line& line);
    bool moveSelShape(const Line& line);
    // onto polys as well:
-   bool polyBegin(const Line& line);
-   bool polyAppend(const Point2f& point);
-   bool polyClose();
-   bool polyCancel();
+   int polyBegin(const Line& line);
+   bool polyAppend(int shape_ref, const Point2f& point);
+   bool polyClose(int shape_ref);
+   bool polyCancel(int shape_ref);
    //
    int addShapeGraph(const std::string& name, int type);
    int addShapeMap(const std::string& name);

--- a/salalib/shapemap.cpp
+++ b/salalib/shapemap.cpp
@@ -2698,8 +2698,11 @@ bool ShapeMap::write( ofstream& stream, int version )
 
    // write next object ref to be used:
    stream.write((char *) &m_obj_ref, sizeof(m_obj_ref));
-   int depr_int = 0;
-   stream.write((char *) &depr_int, sizeof(depr_int));
+
+   // left here for backwards-compatibility
+   // TODO: Remove at next iteration of the .graph file format
+   int largest_shape_ref = m_shapes.key(m_shapes.size()-1);
+   stream.write((char *) &largest_shape_ref, sizeof(largest_shape_ref));
 
    // write shape data
    int count = m_shapes.size();

--- a/salalib/shapemap.cpp
+++ b/salalib/shapemap.cpp
@@ -2788,13 +2788,13 @@ bool ShapeMap::importPoints(const std::vector<Point2f> &points,
 {
     //assumes that points and data come in the same order
 
-    std::vector<int> indices;
+    std::vector<int> shape_refs;
 
     for(auto& point: points) {
-        indices.push_back(makePointShape(point));
+        shape_refs.push_back(makePointShape(point));
     }
 
-    bool dataImported = importData(data, indices);
+    bool dataImported = importData(data, shape_refs);
 
     invalidateDisplayedAttribute();
     setDisplayedAttribute(-1);
@@ -2807,13 +2807,13 @@ bool ShapeMap::importPointsWithRefs(const std::map<int, Point2f> &points,
 {
     //assumes that points and data come in the same order
 
-    std::vector<int> indices;
+    std::vector<int> shape_refs;
 
     for(auto& point: points) {
-        indices.push_back(makePointShapeWithRef(point.second, point.first));
+        shape_refs.push_back(makePointShapeWithRef(point.second, point.first));
     }
 
-    bool dataImported = importData(data, indices);
+    bool dataImported = importData(data, shape_refs);
 
     invalidateDisplayedAttribute();
     setDisplayedAttribute(-1);
@@ -2826,13 +2826,13 @@ bool ShapeMap::importLines(const std::vector<Line> &lines,
 {
     //assumes that lines and data come in the same order
 
-    std::vector<int> indices;
+    std::vector<int> shape_refs;
 
     for(auto& line: lines) {
-        indices.push_back(makeLineShape(line));
+        shape_refs.push_back(makeLineShape(line));
     }
 
-    bool dataImported = importData(data, indices);
+    bool dataImported = importData(data, shape_refs);
 
     invalidateDisplayedAttribute();
     setDisplayedAttribute(-1);
@@ -2845,13 +2845,13 @@ bool ShapeMap::importLinesWithRefs(const std::map<int, Line> &lines,
 {
     //assumes that lines and data come in the same order
 
-    std::vector<int> indices;
+    std::vector<int> shape_refs;
 
     for(auto& line: lines) {
-        indices.push_back(makeLineShapeWithRef(line.second, line.first));
+        shape_refs.push_back(makeLineShapeWithRef(line.second, line.first));
     }
 
-    bool dataImported = importData(data, indices);
+    bool dataImported = importData(data, shape_refs);
 
     invalidateDisplayedAttribute();
     setDisplayedAttribute(-1);
@@ -2864,13 +2864,13 @@ bool ShapeMap::importPolylines(const std::vector<depthmapX::Polyline> &polylines
 {
     //assumes that lines and data come in the same order
 
-    std::vector<int> indices;
+    std::vector<int> shape_refs;
 
     for(auto& polyline: polylines) {
-        indices.push_back(makePolyShape(genshim::toPQVector(polyline.m_vertices), !polyline.m_closed));
+        shape_refs.push_back(makePolyShape(genshim::toPQVector(polyline.m_vertices), !polyline.m_closed));
     }
 
-    bool dataImported = importData(data, indices);
+    bool dataImported = importData(data, shape_refs);
 
     invalidateDisplayedAttribute();
     setDisplayedAttribute(-1);
@@ -2883,13 +2883,13 @@ bool ShapeMap::importPolylinesWithRefs(const std::map<int, depthmapX::Polyline> 
 {
     //assumes that lines and data come in the same order
 
-    std::vector<int> indices;
+    std::vector<int> shape_refs;
 
     for(auto& polyline: polylines) {
-        indices.push_back(makePolyShapeWithRef(genshim::toPQVector(polyline.second.m_vertices), !polyline.second.m_closed, polyline.first));
+        shape_refs.push_back(makePolyShapeWithRef(genshim::toPQVector(polyline.second.m_vertices), !polyline.second.m_closed, polyline.first));
     }
 
-    bool dataImported = importData(data, indices);
+    bool dataImported = importData(data, shape_refs);
 
     invalidateDisplayedAttribute();
     setDisplayedAttribute(-1);
@@ -2897,7 +2897,7 @@ bool ShapeMap::importPolylinesWithRefs(const std::map<int, depthmapX::Polyline> 
     return dataImported;
 }
 
-bool ShapeMap::importData(const depthmapX::Table &data, std::vector<int> indices)
+bool ShapeMap::importData(const depthmapX::Table &data, std::vector<int> shape_refs)
 {
     for (auto& column: data) {
         std::string colName = column.first;
@@ -2937,7 +2937,7 @@ bool ShapeMap::importData(const depthmapX::Table &data, std::vector<int> indices
 
                     if(colcodes.size() >= 32) {
                         for (size_t j = 0; j < column.second.size(); j++) {
-                            m_attributes.setValue(m_attributes.getRowid(indices[j]), colIndex, -1.0f);
+                            m_attributes.setValue(m_attributes.getRowid(shape_refs[j]), colIndex, -1.0f);
                         }
                         continue;
                     } else {
@@ -2948,7 +2948,7 @@ bool ShapeMap::importData(const depthmapX::Table &data, std::vector<int> indices
                     value = cellAt->second;
                 }
             }
-            m_attributes.setValue(m_attributes.getRowid(indices[i]), colIndex, value);
+            m_attributes.setValue(m_attributes.getRowid(shape_refs[i]), colIndex, value);
         }
     }
     return true;

--- a/salalib/shapemap.cpp
+++ b/salalib/shapemap.cpp
@@ -146,7 +146,6 @@ ShapeMap::ShapeMap(const std::string& name, int type) : m_attributes(name)
 
    // shape and object counters
    m_obj_ref = -1;
-   m_shape_ref = -1;
    // pixel map
    m_pixel_shapes = NULL;
    //
@@ -237,7 +236,6 @@ void ShapeMap::copy(const ShapeMap& sourcemap, int copyflags)
 {
    if ((copyflags & ShapeMap::COPY_GEOMETRY) == ShapeMap::COPY_GEOMETRY) {
       m_shapes.clear();
-      m_shape_ref = -1;
       init(sourcemap.m_shapes.size(),sourcemap.m_region);
       for (size_t i = 0; i < sourcemap.m_shapes.size(); i++) {
          // using makeShape is actually easier than thinking about a total copy:
@@ -307,7 +305,6 @@ void ShapeMap::clearAll()
    m_region = QtRegion();
 
    m_obj_ref = -1;
-   m_shape_ref = -1;
    m_displayed_attribute = -1; 
 }
 
@@ -323,12 +320,12 @@ int ShapeMap::makePointShape(const Point2f& point, bool tempshape)
       init(m_shapes.size(),QtRegion(point,point));
    }
 
-   m_shape_ref++;
-   int x = m_shapes.add(m_shape_ref,SalaShape(point));
+   int new_shape_ref = getNextShapeKey();
+   int x = m_shapes.add(new_shape_ref,SalaShape(point));
 
    if (bounds_good) {
       // note: also sets polygon bounding box:
-      makePolyPixels(m_shape_ref);
+      makePolyPixels(new_shape_ref);
    }
    else {
       // pixelate all polys in the pixel new structure:
@@ -338,11 +335,11 @@ int ShapeMap::makePointShape(const Point2f& point, bool tempshape)
    }
 
    if (!tempshape) {
-      int rowid = m_attributes.insertRow(m_shape_ref);
+      int rowid = m_attributes.insertRow(new_shape_ref);
       m_newshape = true;
    }
 
-   return m_shape_ref;
+   return new_shape_ref;
 }
 
 int ShapeMap::makeLineShape(const Line& line, bool through_ui, bool tempshape)
@@ -358,14 +355,16 @@ int ShapeMap::makeLineShape(const Line& line, bool through_ui, bool tempshape)
       bounds_good = false;
       init(m_shapes.size(),line);
    }
-  
-   m_shape_ref++;
+
+
+   int new_shape_ref = getNextShapeKey();
+
    // note, shape constructor sets centroid, length etc
-   int rowid = m_shapes.add(m_shape_ref,SalaShape(line));
+   int rowid = m_shapes.add(new_shape_ref,SalaShape(line));
 
    if (bounds_good) {
       // note: also sets polygon bounding box:
-      makePolyPixels(m_shape_ref);
+      makePolyPixels(new_shape_ref);
    }
    else {
       // pixelate all polys in the pixel new structure:
@@ -375,7 +374,7 @@ int ShapeMap::makeLineShape(const Line& line, bool through_ui, bool tempshape)
    }
 
    if (!tempshape) {
-      m_attributes.insertRow(m_shape_ref);
+      m_attributes.insertRow(new_shape_ref);
       m_newshape = true;
    }
 
@@ -391,13 +390,18 @@ int ShapeMap::makeLineShape(const Line& line, bool through_ui, bool tempshape)
          }
       }
       // if through ui, set undo counter:
-      m_undobuffer.push_back(SalaEvent(SalaEvent::SALA_CREATED,m_shape_ref));
+      m_undobuffer.push_back(SalaEvent(SalaEvent::SALA_CREATED, new_shape_ref));
       // update displayed attribute if through ui:
       invalidateDisplayedAttribute();
       setDisplayedAttribute(m_displayed_attribute);
    }
 
-   return m_shape_ref;
+   return new_shape_ref;
+}
+
+int ShapeMap::getNextShapeKey() {
+    if(m_shapes.size() == 0) return 0;
+    return m_shapes.key(m_shapes.size() - 1) + 1;
 }
 
 int ShapeMap::makePolyShape(const pqvector<Point2f>& points, bool open, bool tempshape)
@@ -423,7 +427,7 @@ int ShapeMap::makePolyShape(const pqvector<Point2f>& points, bool open, bool tem
       init(m_shapes.size(),region);
    }
 
-   m_shape_ref++;
+   int new_shape_ref = getNextShapeKey();
 
    size_t len = points.size();
    // NOTE: This is commented out deliberately
@@ -438,10 +442,10 @@ int ShapeMap::makePolyShape(const pqvector<Point2f>& points, bool open, bool tem
    // not sure if it matters if the polygon is clockwise or anticlockwise... we'll soon tell!
 
    if (open) {
-      m_shapes.add(m_shape_ref,SalaShape(SalaShape::SHAPE_POLY));
+      m_shapes.add(new_shape_ref,SalaShape(SalaShape::SHAPE_POLY));
    }
    else {
-      m_shapes.add(m_shape_ref,SalaShape(SalaShape::SHAPE_POLY | SalaShape::SHAPE_CLOSED));
+      m_shapes.add(new_shape_ref,SalaShape(SalaShape::SHAPE_POLY | SalaShape::SHAPE_CLOSED));
    }
    for (i = 0; i < len; i++) {
       m_shapes.tail().push_back(points[i]);
@@ -449,7 +453,7 @@ int ShapeMap::makePolyShape(const pqvector<Point2f>& points, bool open, bool tem
 
    if (bounds_good) {
       // note: also sets polygon bounding box:
-      makePolyPixels(m_shape_ref);
+      makePolyPixels(new_shape_ref);
    }
    else {
       // pixelate all polys in the pixel new structure:
@@ -461,11 +465,11 @@ int ShapeMap::makePolyShape(const pqvector<Point2f>& points, bool open, bool tem
    if (!tempshape) {
       // set centroid now also adds a few other things: as well as area, perimeter
       m_shapes.tail().setCentroidAreaPerim();
-      m_attributes.insertRow(m_shape_ref);
+      m_attributes.insertRow(new_shape_ref);
       m_newshape = true;
    }
 
-   return m_shape_ref;
+   return new_shape_ref;
 }
 
 int ShapeMap::makeShape(const SalaShape& poly, int override_shape_ref)
@@ -484,13 +488,9 @@ int ShapeMap::makeShape(const SalaShape& poly, int override_shape_ref)
 
    int shape_ref;
    if (override_shape_ref == -1) {
-      m_shape_ref++;
-      shape_ref = m_shape_ref;
+      shape_ref = getNextShapeKey();
    }
    else {
-      if (override_shape_ref > m_shape_ref) {
-         m_shape_ref = override_shape_ref;
-      }
       shape_ref = override_shape_ref;
    }
 
@@ -582,12 +582,12 @@ int ShapeMap::makeShapeFromPointSet(const PointMap& pointmap)
    }
    poly.setCentroidAreaPerim();
 
-   m_shape_ref++;
-   int rowid = m_shapes.add(m_shape_ref,poly);
+   int new_shape_ref = getNextShapeKey();
+   int rowid = m_shapes.add(new_shape_ref,poly);
 
    if (bounds_good) {
       // note: also sets polygon bounding box:
-      makePolyPixels(m_shape_ref);
+      makePolyPixels(new_shape_ref);
    }
    else {
       // pixelate all polys in the pixel new structure:
@@ -596,10 +596,10 @@ int ShapeMap::makeShapeFromPointSet(const PointMap& pointmap)
       }
    }
    
-   m_attributes.insertRow(m_shape_ref);
+   m_attributes.insertRow(new_shape_ref);
    m_newshape = true;
    
-   return m_shape_ref;
+   return new_shape_ref;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -799,13 +799,13 @@ int ShapeMap::polyBegin(const Line& line)
       bounds_good = false;
       init(m_shapes.size(),line);
    }
-   m_shape_ref++;
-   int rowid = m_shapes.add(m_shape_ref,SalaShape(line));
+   int new_shape_ref = getNextShapeKey();
+   int rowid = m_shapes.add(new_shape_ref,SalaShape(line));
    m_shapes.tail().m_centroid = line.getCentre();
 
    if (bounds_good) {
       // note: also sets polygon bounding box:
-      makePolyPixels(m_shape_ref);
+      makePolyPixels(new_shape_ref);
    }
    else {
       // pixelate all polys in the pixel new structure:
@@ -815,7 +815,7 @@ int ShapeMap::polyBegin(const Line& line)
    }
 
    // insert into attributes
-   m_attributes.insertRow(m_shape_ref);
+   m_attributes.insertRow(new_shape_ref);
    // would usually set attributes here, but actually, really want
    // to set the attributes only when the user completes the drawing
 
@@ -830,16 +830,16 @@ int ShapeMap::polyBegin(const Line& line)
    m_newshape = true;
 
    // set undo counter:
-   m_undobuffer.push_back(SalaEvent(SalaEvent::SALA_CREATED,m_shape_ref));
+   m_undobuffer.push_back(SalaEvent(SalaEvent::SALA_CREATED,new_shape_ref));
 
    // update displayed attribute
    invalidateDisplayedAttribute();
    setDisplayedAttribute(m_displayed_attribute);
 
-   return m_shape_ref;
+   return new_shape_ref;
 }
 
-bool ShapeMap::polyAppend(const Point2f& point)
+bool ShapeMap::polyAppend(int shape_ref, const Point2f& point)
 {
    // don't do anything too complex:
    SalaShape& shape = m_shapes.tail();
@@ -850,7 +850,7 @@ bool ShapeMap::polyAppend(const Point2f& point)
    }
 
    // junk the old shape pixels:
-   removePolyPixels(m_shape_ref);
+   removePolyPixels(shape_ref);
    
    bool bounds_good = true;
    if (!m_region.contains_touch(point)) {
@@ -869,7 +869,7 @@ bool ShapeMap::polyAppend(const Point2f& point)
 
    if (bounds_good) {
       // note: also sets polygon bounding box:
-      makePolyPixels(m_shape_ref);
+      makePolyPixels(shape_ref);
    }
    else {
       // pixelate all polys in the pixel new structure:
@@ -883,7 +883,7 @@ bool ShapeMap::polyAppend(const Point2f& point)
    return true;
 }
 
-bool ShapeMap::polyClose()
+bool ShapeMap::polyClose(int shape_ref)
 {
    // don't do anything too complex:
    SalaShape& shape = m_shapes.tail();
@@ -894,16 +894,16 @@ bool ShapeMap::polyClose()
    }
 
    // junk the old shape pixels:
-   removePolyPixels(m_shape_ref);
+   removePolyPixels(shape_ref);
 
    shape.m_type |= SalaShape::SHAPE_CLOSED;
 
-   makePolyPixels(m_shape_ref);
+   makePolyPixels(shape_ref);
 
    return true;
 }
 
-bool ShapeMap::polyCancel()
+bool ShapeMap::polyCancel(int shape_ref)
 {
    // don't do anything too complex:
    SalaShape& shape = m_shapes.tail();
@@ -914,7 +914,7 @@ bool ShapeMap::polyCancel()
    }
 
    m_undobuffer.pop_back();
-   removeShape(m_shape_ref,true);
+   removeShape(shape_ref,true);
 
    // update displayed attribute
    invalidateDisplayedAttribute();
@@ -949,22 +949,22 @@ int ShapeMap::shapeEnd(bool open)
       m_region.encompass(m_temppoints[i]);
    }
 
-   m_shape_ref++;
+   int new_shape_ref = getNextShapeKey();
 
    int rowid = -1;
    
    if (len == 1) {
-      rowid = m_shapes.add(m_shape_ref,SalaShape(m_temppoints[0]));
+      rowid = m_shapes.add(new_shape_ref,SalaShape(m_temppoints[0]));
    }
    else if (len == 2) {
-      rowid = m_shapes.add(m_shape_ref,SalaShape(Line(m_temppoints[0],m_temppoints[1])));
+      rowid = m_shapes.add(new_shape_ref,SalaShape(Line(m_temppoints[0],m_temppoints[1])));
    }
    else {
       if (open) {
-         rowid = m_shapes.add(m_shape_ref,SalaShape(SalaShape::SHAPE_POLY));
+         rowid = m_shapes.add(new_shape_ref,SalaShape(SalaShape::SHAPE_POLY));
       }
       else {
-         rowid = m_shapes.add(m_shape_ref,SalaShape(SalaShape::SHAPE_POLY | SalaShape::SHAPE_CLOSED));
+         rowid = m_shapes.add(new_shape_ref,SalaShape(SalaShape::SHAPE_POLY | SalaShape::SHAPE_CLOSED));
       }
       if (rowid != -1) {
          SalaShape& shape = m_shapes[rowid];
@@ -976,7 +976,7 @@ int ShapeMap::shapeEnd(bool open)
    }
 
    if (rowid != -1) {
-      m_attributes.insertRow(m_shape_ref);
+      m_attributes.insertRow(new_shape_ref);
 
       if (m_hasgraph) {
          while (m_connectors.size() < m_shapes.size()) {
@@ -1097,11 +1097,6 @@ void ShapeMap::removeShape(int shaperef, bool undoing)
 
    // n.b., shaperef should have been used to create the row in the first place:
    m_attributes.removeRow(shaperef);
-
-   // if undoing the final shape, might as well reuse the shape ref:
-   if (undoing && shaperef == m_shape_ref) {
-      m_shape_ref--;
-   }
 
    m_newshape = true;
    m_invalidate = true;
@@ -1802,7 +1797,6 @@ void ShapeMap::shapeInPolyList(const SalaShape& shape, pvecint& shapeindexlist) 
       removePolyPixels(ref);
       size_t rowid = m_shapes.searchindex(ref);
       m_shapes.remove_at(rowid);
-      m_shape_ref--; // also undo temporary shaperef, or it could get out of hand with lots of tests
    }
 }
 
@@ -2621,7 +2615,8 @@ bool ShapeMap::read( istream& stream, int version, bool drawinglayer )
 
    // read next object ref to be used:
    stream.read((char *) &m_obj_ref, sizeof(m_obj_ref));
-   stream.read((char *) &m_shape_ref, sizeof(m_shape_ref));
+   int depr_int;
+   stream.read((char *) &depr_int, sizeof(depr_int));
 
    // read shape data
    int count = 0;
@@ -2703,7 +2698,8 @@ bool ShapeMap::write( ofstream& stream, int version )
 
    // write next object ref to be used:
    stream.write((char *) &m_obj_ref, sizeof(m_obj_ref));
-   stream.write((char *) &m_shape_ref, sizeof(m_shape_ref));
+   int depr_int = 0;
+   stream.write((char *) &depr_int, sizeof(depr_int));
 
    // write shape data
    int count = m_shapes.size();
@@ -2873,7 +2869,7 @@ bool ShapeMap::importData(const depthmapX::Table &data, std::vector<int> indices
 
                     if(colcodes.size() >= 32) {
                         for (size_t j = 0; j < column.second.size(); j++) {
-                            m_attributes.setValue(indices[j], colIndex, -1.0f);
+                            m_attributes.setValue(m_attributes.getRowid(indices[j]), colIndex, -1.0f);
                         }
                         continue;
                     } else {
@@ -2884,7 +2880,7 @@ bool ShapeMap::importData(const depthmapX::Table &data, std::vector<int> indices
                     value = cellAt->second;
                 }
             }
-            m_attributes.setValue(indices[i], colIndex, value);
+            m_attributes.setValue(m_attributes.getRowid(indices[i]), colIndex, value);
         }
     }
     return true;

--- a/salalib/shapemap.h
+++ b/salalib/shapemap.h
@@ -550,7 +550,7 @@ public:
    bool importPolylines(const std::vector<depthmapX::Polyline> &lines, const depthmapX::Table &data);
    bool importPolylinesWithRefs(const std::map<int, depthmapX::Polyline> &lines, const depthmapX::Table &data);
 private:
-   bool importData(const depthmapX::Table &data, std::vector<int> indices);
+   bool importData(const depthmapX::Table &data, std::vector<int> shape_refs);
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/salalib/shapemap.h
+++ b/salalib/shapemap.h
@@ -204,7 +204,6 @@ protected:
    bool m_hasgraph;
    // counters
    int m_obj_ref;
-   int m_shape_ref;
    mutable bool m_newshape;   // if a new shape has been added
    //
    // quick grab for shapes
@@ -261,6 +260,7 @@ public:
    //
    //
    void init(int size, const QtRegion& r);
+   int getNextShapeKey();
    // convert a single point into a shape
    int makePointShape(const Point2f& point, bool tempshape = false);
    // or a single line into a shape
@@ -286,9 +286,9 @@ public:
    //
    // some UI polygon creation tools:
    int polyBegin(const Line& line);
-   bool polyAppend(const Point2f& point);
-   bool polyClose();
-   bool polyCancel();
+   bool polyAppend(int shape_ref, const Point2f& point);
+   bool polyClose(int shape_ref);
+   bool polyCancel(int shape_ref);
    // some shape creation tools for the scripting language or DLL interface
 protected:
    pqvector<Point2f> m_temppoints;
@@ -390,7 +390,7 @@ public:
    double getDisplayMinValue() const
    { return (m_displayed_attribute != -1) ? m_attributes.getMinValue(m_displayed_attribute) : 0; } 
    double getDisplayMaxValue() const
-   { return (m_displayed_attribute != -1) ? m_attributes.getMaxValue(m_displayed_attribute) : m_shape_ref; } 
+   { return (m_displayed_attribute != -1) ? m_attributes.getMaxValue(m_displayed_attribute) : m_shapes.key(m_shapes.size()-1); }
    //
    mutable DisplayParams m_display_params;
    const DisplayParams& getDisplayParams() const

--- a/salalib/shapemap.h
+++ b/salalib/shapemap.h
@@ -262,10 +262,13 @@ public:
    void init(int size, const QtRegion& r);
    int getNextShapeKey();
    // convert a single point into a shape
+   int makePointShapeWithRef(const Point2f& point, int shape_ref, bool tempshape = false);
    int makePointShape(const Point2f& point, bool tempshape = false);
    // or a single line into a shape
+   int makeLineShapeWithRef(const Line& line, int shape_ref, bool through_ui = false, bool tempshape = false);
    int makeLineShape(const Line& line, bool through_ui = false, bool tempshape = false);
    // or a polygon into a shape
+   int makePolyShapeWithRef(const pqvector<Point2f>& points, bool open, int shape_ref, bool tempshape = false);
    int makePolyShape(const pqvector<Point2f>& points, bool open, bool tempshape = false);
 public:
    // or make a shape from a shape
@@ -541,8 +544,11 @@ public:
    std::vector<std::pair<SimpleLine, PafColor>> getAllLinesWithColour();
    std::map<std::vector<Point2f>, PafColor> getAllPolygonsWithColour();
    bool importLines(const std::vector<Line> &lines, const depthmapX::Table &data);
+   bool importLinesWithRefs(const std::map<int, Line> &lines, const depthmapX::Table &data);
    bool importPoints(const std::vector<Point2f> &points, const depthmapX::Table &data);
+   bool importPointsWithRefs(const std::map<int, Point2f> &points, const depthmapX::Table &data);
    bool importPolylines(const std::vector<depthmapX::Polyline> &lines, const depthmapX::Table &data);
+   bool importPolylinesWithRefs(const std::map<int, depthmapX::Polyline> &lines, const depthmapX::Table &data);
 private:
    bool importData(const depthmapX::Table &data, std::vector<int> indices);
 };


### PR DESCRIPTION
Thus allows carrying the refid through the various conversions (and allows us to break internal code)

**Some of the whitespace was converted to spaces by Qt creator, append ?w=1 to the url of this diff to see without the changes**