### PR TITLE
Agents fix assignments in conditionals

### DIFF
--- a/salalib/nagent.cpp
+++ b/salalib/nagent.cpp
@@ -402,6 +402,7 @@ AgentProgram crossover(const AgentProgram& prog_a, const AgentProgram& prog_b)
    return child;
 }
 
+// TODO: Expose this functionality to the UIs
 void AgentProgram::save(const std::string& filename)
 {
    // standard ascii:
@@ -876,6 +877,7 @@ Point2f Agent::onStandardLook(bool wholeisovist)
    return (m_target - m_loc).normalise();
 }
 
+// TODO: Expose this functionality to the UIs
 Point2f Agent::onWeightedLook(bool wholeisovist)
 {
    if (wholeisovist) {

--- a/salalib/nagent.cpp
+++ b/salalib/nagent.cpp
@@ -950,7 +950,7 @@ Point2f Agent::onOcclusionLook(bool wholeisovist, int looktype)
    }
    PixelRef tarpixelate = NoPixel;
    int vbin = m_program->m_vbin;
-   if (vbin = -1) {
+   if (vbin == -1) {
       vbin = 16;
    }
    int directionbin = 32 + binfromvec(m_vector) - vbin;

--- a/salalib/nagent.cpp
+++ b/salalib/nagent.cpp
@@ -515,7 +515,7 @@ bool AgentProgram::open(const std::string& filename)
          std::string bins = line.substr(6);
          dXstring::ltrim(bins);
          int binx = stoi(bins);
-         if (binx = 32) {
+         if (binx == 32) {
             m_vbin = -1;
          }
          else {
@@ -884,7 +884,7 @@ Point2f Agent::onWeightedLook(bool wholeisovist)
    }
    int tarpixelate = -1;
    int vbin = m_program->m_vbin;
-   if (vbin = -1) {
+   if (vbin == -1) {
       vbin = 16;
    }
    int aheadbin = binfromvec(m_vector);


### PR DESCRIPTION
The output for every bin has been tested for "occlusion-all" look in the gallery with these parameters:

timesteps: 5000
release rate: 0.1
field-of-view: variable
steps between decisions: 3
total agent life: 500
intial location seed: 0

Below is a set of (pearson) correlation matrices made with [pandas.DataFrame.corr](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.corr.html) showing how well the analysis above correlates between different fields of view (bins). The compared metric is the number of times agents passed over each VGA grid cell (0.40x0.40)

Bins compared to themselves (top left to bottom right diagonal) always show high correlation (as the results are the same) but the results as we move away from the diagonal should correlate as well. 

The occlusion looks (onOcclusionLook()) depend on the standard look as it is called in various parts of the function (i.e. when the agent is stuck) and once in the beginning (there's an onLook(wholeisovist = true) in the initialisation of the agents)

This is the current situation (vbin is always set to 16 because of assignment in conditional (nagent.cpp:953):
![agents_ depthmapxcli_bad_occ_good_std](https://user-images.githubusercontent.com/2184600/38222064-b0ade37c-36da-11e8-91a7-811782d844ca.png)
It is not obvious that the user-set bin does not really change but when the standard look also has vbin set to 16 always then the result is:
![agents_ depthmapxcli_bad_occ_bad_std](https://user-images.githubusercontent.com/2184600/38222410-8433d52a-36dc-11e8-9bfb-41dd80d16eff.png)
... which means that indeed the assignment in the conditional does always create the same results no matter what visual field is given to the agents. Both the standard and occlusion looks need to take user input as here's what happens when the occlusion look properly handles user input but the standard look remains fixed to 16:
![agents_ depthmapxcli_good_occ_bad_std](https://user-images.githubusercontent.com/2184600/38222469-ca57d3c6-36dc-11e8-96e8-9d06a2bffa8b.png)
And here's the result when both take proper input from the user:
![agents_ depthmapxcli_good_occ_good_std](https://user-images.githubusercontent.com/2184600/38222488-e76c2fa2-36dc-11e8-8e42-bd5c912825b9.png)

For completeness here's the actual pairs plot between all bins before (first matrix):
![agents_scatter_bad_occ_good_std](https://user-images.githubusercontent.com/2184600/38223189-7e7c41ee-36e1-11e8-9200-b78e0542cd99.png)
and after (last matrix):
![agents_scatter](https://user-images.githubusercontent.com/2184600/38222786-f11636ae-36de-11e8-9be7-fa3a7f34c198.png)

The onWeightedLook() function is also fixed although it's never used (but could probably be revived)
The open() function is fixed as well although that can not be tested unless the save() function is exposed (now it's not called from anywhere)
