### PR TITLE
Make sure the seedref centre is visible from the seed when filling

### DIFF
--- a/salalib/pointdata.cpp
+++ b/salalib/pointdata.cpp
@@ -528,8 +528,6 @@ bool PointMap::makePoints(const Point2f& seed, int fill_type, Communicator *comm
        }
    }
 
-
-
    if (!m_blockedlines) {
       blockLines();
    }

--- a/salalib/pointdata.cpp
+++ b/salalib/pointdata.cpp
@@ -520,6 +520,16 @@ bool PointMap::makePoints(const Point2f& seed, int fill_type, Communicator *comm
       return false;
    }
 
+   // check if seed point is actually visible from the centre of the cell
+   std::map<int, Line>& linesTouching = getPoint(seedref).m_lines;
+   for(auto line: linesTouching) {
+       if(intersect_line_no_touch(line.second, Line(seed, getPoint(seedref).m_location))) {
+           return false;
+       }
+   }
+
+
+
    if (!m_blockedlines) {
       blockLines();
    }


### PR DESCRIPTION
Make sure the centre of the seedref (pixel to start filling from) is actually visible from the seed (exact point clicked) when filling the grid

This can be seen in the example below: Currently (left) when clicking within the red area a pixel is selected (noted in blue), and the filling process starts from the centre of that pixel. The result is visible on the right.
![wheretoclick](https://user-images.githubusercontent.com/2184600/39303820-7db7582c-494f-11e8-9151-609de5a60bda.png) ![result](https://user-images.githubusercontent.com/2184600/39304005-1694923a-4950-11e8-933d-cac3f7e541c6.png)
The problem is that the user has actually clicked within the **below** general area not the above (which is the one that gets to be filled).
This change first checks if the pixel centre is actually visible from the clicked point and only fills it then
