### PR TITLE
 Make sure m_displayed_pointmap never goes below 0

### DIFF
--- a/salaTest/testmgraph.cpp
+++ b/salaTest/testmgraph.cpp
@@ -104,6 +104,6 @@ TEST_CASE("Test pointMaps", "")
         mgraph->removeDisplayedMap();
         REQUIRE(mgraph->getPointMaps().size() == 1);
         REQUIRE(mgraph->getPointMaps()[0].getName() == "Stan");
-        REQUIRE(mgraph->getDisplayedPointMapRef() == -1);
+        REQUIRE(mgraph->getDisplayedPointMapRef() == 0);
     }
 }

--- a/salalib/mgraph.h
+++ b/salalib/mgraph.h
@@ -102,7 +102,11 @@ private:
    void setSpacePixel(SuperSpacePixel *spacepix)
    { m_spacepix = spacepix; for (auto& pointMap: m_pointMaps) pointMap.setSpacePixel(spacepix); }
    void removePointMap(int i)
-   { if (m_displayed_pointmap >= i) m_displayed_pointmap--; m_pointMaps.erase(m_pointMaps.begin() + i); }
+   {
+       if (m_displayed_pointmap >= i) m_displayed_pointmap--;
+       if(m_displayed_pointmap < 0) m_displayed_pointmap = 0;
+       m_pointMaps.erase(m_pointMaps.begin() + i);
+   }
 
    bool readPointMaps(istream &stream, int version );
    bool writePointMaps( ofstream& stream, int version, bool displayedmaponly = false );


### PR DESCRIPTION
Currently m_displayed_pointmap can go below 0, but this crashes the application if two maps are created and the first one is deleted. In this case m_displayed_pointmap (= 0) is deleted and while it should stay 0 (thus pointing to the remaining pointmap) it becomes -1.