### PR TITLE
Blsemo/198 attrib cleanup

### DIFF
--- a/salalib/axialmap.cpp
+++ b/salalib/axialmap.cpp
@@ -1277,7 +1277,6 @@ int ShapeGraphs::convertDrawingToAxial(Communicator *comm, const std::string& na
    // we can stop here for all line axial map!
    ShapeGraph& usermap = tail();
 
-
    usermap.init(lines.size(),region);        // used to be double density
    std::map<int, float> layerAttributes;
    usermap.initialiseAttributesAxial();
@@ -1362,7 +1361,7 @@ int ShapeGraphs::convertDataToAxial(Communicator *comm, const std::string& name,
        for (int i = 0; i < input.getColumnCount(); i++) {
           std::string colname = input.getColumnName(i);
           for (size_t k = 1; output.getColumnIndex(colname) != -1; k++){
-             colname = dXstring::formatString((int)k,input.getColumnName(i) + " copy %d");
+             colname = dXstring::formatString((int)k,input.getColumnName(i) + " %d");
           }
           columns.push_back( output.insertColumn(colname));
        }

--- a/salalib/axialmap.cpp
+++ b/salalib/axialmap.cpp
@@ -1569,7 +1569,7 @@ int ShapeGraphs::convertDrawingToSegment(Communicator *comm, const std::string& 
 
    usermap.init(lines.size(),region);
    std::map<int, float> layerAttributes;
-   usermap.initialiseAttributesAxial();
+   usermap.initialiseAttributesSegment();
    int layerCol = -1;
    if (recordlayer)   {
        layerCol = usermap.getAttributeTable().insertColumn("Drawing Layer");

--- a/salalib/axialmap.h
+++ b/salalib/axialmap.h
@@ -193,6 +193,7 @@ public:
 public:
    ShapeGraph(const std::string& name = "<axial map>", int type = ShapeMap::AXIALMAP);
    virtual ~ShapeGraph() {;}
+   void initialiseAttributesAxial();
    void makeConnections(const prefvec<pvecint>& keyvertices = prefvec<pvecint>());
    //void initAttributes();
    void makeDivisions(const prefvec<PolyConnector>& polyconnections, const pqvector<RadialLine>& radiallines, std::map<RadialKey, pvecint> &radialdivisions, std::map<int,pvecint>& axialdividers, Communicator *comm);
@@ -208,6 +209,7 @@ public:
    // lineset and connectionset are filled in by segment map
    void makeNewSegMap();
    void makeSegmentMap(std::vector<Line> &lineset, prefvec<Connector>& connectionset, double stubremoval);
+   void initialiseAttributesSegment();
    void initSegmentAttributes(prefvec<Connector>& connectionset);
    void makeSegmentConnections(prefvec<Connector>& connectionset);
    void pushAxialValues(ShapeGraph& axialmap);

--- a/salalib/axialmap.h
+++ b/salalib/axialmap.h
@@ -210,7 +210,6 @@ public:
    void makeNewSegMap();
    void makeSegmentMap(std::vector<Line> &lineset, prefvec<Connector>& connectionset, double stubremoval);
    void initialiseAttributesSegment();
-   void initSegmentAttributes(prefvec<Connector>& connectionset);
    void makeSegmentConnections(prefvec<Connector>& connectionset);
    void pushAxialValues(ShapeGraph& axialmap);
    //

--- a/salalib/shapemap.cpp
+++ b/salalib/shapemap.cpp
@@ -306,7 +306,7 @@ int ShapeMap::makePointShape(const Point2f& point, bool tempshape)
     return makePointShapeWithRef(point, getNextShapeKey(), tempshape);
 }
 
-int ShapeMap::makeLineShapeWithRef(const Line& line, int shape_ref, bool through_ui, bool tempshape)
+int ShapeMap::makeLineShapeWithRef(const Line& line, int shape_ref, bool through_ui, bool tempshape, int layerCol, float layerVal)
 {
    // note, map must have editable flag on if we are to make a shape through the user interface:
    if (through_ui && !m_editable) {
@@ -335,7 +335,10 @@ int ShapeMap::makeLineShapeWithRef(const Line& line, int shape_ref, bool through
    }
 
    if (!tempshape) {
-      m_attributes.insertRow(shape_ref);
+      int rowIndex = m_attributes.insertRow(shape_ref);
+      if ( layerCol != -1){
+        m_attributes.setValue(rowIndex, layerCol, layerVal);
+      }
       m_newshape = true;
    }
 
@@ -365,12 +368,12 @@ int ShapeMap::getNextShapeKey() {
     return m_shapes.rbegin()->first + 1;
 }
 
-int ShapeMap::makeLineShape(const Line& line, bool through_ui, bool tempshape)
+int ShapeMap::makeLineShape(const Line& line, bool through_ui, bool tempshape, int layerCol, float layerVal)
 {
-    return makeLineShapeWithRef(line, getNextShapeKey(), through_ui, tempshape);
+    return makeLineShapeWithRef(line, getNextShapeKey(), through_ui, tempshape, layerCol, layerVal);
 }
 
-int ShapeMap::makePolyShapeWithRef(const std::vector<Point2f>& points, bool open, int shape_ref, bool tempshape)
+int ShapeMap::makePolyShapeWithRef(const std::vector<Point2f>& points, bool open, int shape_ref, bool tempshape, int layerCol, float layerVal)
 {
    bool bounds_good = true;
 
@@ -429,19 +432,22 @@ int ShapeMap::makePolyShapeWithRef(const std::vector<Point2f>& points, bool open
    if (!tempshape) {
       // set centroid now also adds a few other things: as well as area, perimeter
       m_shapes.rbegin()->second.setCentroidAreaPerim();
-      m_attributes.insertRow(shape_ref);
+      int rowIndex = m_attributes.insertRow(shape_ref);
+      if ( layerCol != -1 ){
+          m_attributes.setValue(rowIndex, layerCol, layerVal);
+      }
       m_newshape = true;
    }
 
    return shape_ref;
 }
 
-int ShapeMap::makePolyShape(const std::vector<Point2f>& points, bool open, bool tempshape)
+int ShapeMap::makePolyShape(const std::vector<Point2f>& points, bool open, bool tempshape, int layerCol, float layerVal)
 {
-    return makePolyShapeWithRef(points, open, getNextShapeKey(), tempshape);
+    return makePolyShapeWithRef(points, open, getNextShapeKey(), tempshape, layerCol, layerVal);
 }
 
-int ShapeMap::makeShape(const SalaShape& poly, int override_shape_ref)
+int ShapeMap::makeShape(const SalaShape& poly, int override_shape_ref, int layerCol, float layerVal)
 {
    // overridden shape cannot exist:
    if (override_shape_ref != -1 && m_shapes.find(override_shape_ref) != m_shapes.end()) {
@@ -476,14 +482,11 @@ int ShapeMap::makeShape(const SalaShape& poly, int override_shape_ref)
       }
    }
 
-   int rowid2 = m_attributes.insertRow(shape_ref);
-
-#ifdef _DEBUG
-   if (rowid1 != rowid2) {
-      // rowids should match, they're both pqmaps, but if someone is stupid enough to change it, they'll know pretty quickly:
-      throw depthmapX::RuntimeException("Arrrrgghhh: important! insertRow does not index in the same way as add shapes, this will badly mess up the system!");
+   int rowIndex = m_attributes.insertRow(shape_ref);
+   if ( layerCol != -1 ){
+       m_attributes.setValue(rowIndex, layerCol, layerVal);
    }
-#endif
+
 
    m_newshape = true;
 

--- a/salalib/shapemap.cpp
+++ b/salalib/shapemap.cpp
@@ -271,7 +271,7 @@ void ShapeMap::clearAll()
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-int ShapeMap::makePointShapeWithRef(const Point2f& point, int shape_ref, bool tempshape)
+int ShapeMap::makePointShapeWithRef(const Point2f& point, int shape_ref, bool tempshape, const std::map<int, float> &extraAttributes)
 {
    bool bounds_good = true;
 
@@ -295,18 +295,21 @@ int ShapeMap::makePointShapeWithRef(const Point2f& point, int shape_ref, bool te
 
    if (!tempshape) {
       int rowid = m_attributes.insertRow(shape_ref);
+      for ( auto &attr : extraAttributes){
+          m_attributes.setValue(rowid, attr.first, attr.second);
+      }
       m_newshape = true;
    }
 
    return shape_ref;
 }
 
-int ShapeMap::makePointShape(const Point2f& point, bool tempshape)
+int ShapeMap::makePointShape(const Point2f& point, bool tempshape, const std::map<int,float> &extraAttributes)
 {
-    return makePointShapeWithRef(point, getNextShapeKey(), tempshape);
+    return makePointShapeWithRef(point, getNextShapeKey(), tempshape, extraAttributes);
 }
 
-int ShapeMap::makeLineShapeWithRef(const Line& line, int shape_ref, bool through_ui, bool tempshape, int layerCol, float layerVal)
+int ShapeMap::makeLineShapeWithRef(const Line& line, int shape_ref, bool through_ui, bool tempshape, const std::map<int,float> &extraAttributes)
 {
    // note, map must have editable flag on if we are to make a shape through the user interface:
    if (through_ui && !m_editable) {
@@ -336,8 +339,8 @@ int ShapeMap::makeLineShapeWithRef(const Line& line, int shape_ref, bool through
 
    if (!tempshape) {
       int rowIndex = m_attributes.insertRow(shape_ref);
-      if ( layerCol != -1){
-        m_attributes.setValue(rowIndex, layerCol, layerVal);
+      for (auto &attr : extraAttributes){
+          m_attributes.setValue(rowIndex, attr.first, attr.second);
       }
       m_newshape = true;
    }
@@ -368,12 +371,12 @@ int ShapeMap::getNextShapeKey() {
     return m_shapes.rbegin()->first + 1;
 }
 
-int ShapeMap::makeLineShape(const Line& line, bool through_ui, bool tempshape, int layerCol, float layerVal)
+int ShapeMap::makeLineShape(const Line& line, bool through_ui, bool tempshape, const std::map<int,float> &extraAttributes)
 {
-    return makeLineShapeWithRef(line, getNextShapeKey(), through_ui, tempshape, layerCol, layerVal);
+    return makeLineShapeWithRef(line, getNextShapeKey(), through_ui, tempshape, extraAttributes);
 }
 
-int ShapeMap::makePolyShapeWithRef(const std::vector<Point2f>& points, bool open, int shape_ref, bool tempshape, int layerCol, float layerVal)
+int ShapeMap::makePolyShapeWithRef(const std::vector<Point2f>& points, bool open, int shape_ref, bool tempshape, const std::map<int,float> &extraAttributes)
 {
    bool bounds_good = true;
 
@@ -433,8 +436,8 @@ int ShapeMap::makePolyShapeWithRef(const std::vector<Point2f>& points, bool open
       // set centroid now also adds a few other things: as well as area, perimeter
       m_shapes.rbegin()->second.setCentroidAreaPerim();
       int rowIndex = m_attributes.insertRow(shape_ref);
-      if ( layerCol != -1 ){
-          m_attributes.setValue(rowIndex, layerCol, layerVal);
+      for ( auto &attr : extraAttributes){
+          m_attributes.setValue(rowIndex, attr.first, attr.second);
       }
       m_newshape = true;
    }
@@ -442,12 +445,12 @@ int ShapeMap::makePolyShapeWithRef(const std::vector<Point2f>& points, bool open
    return shape_ref;
 }
 
-int ShapeMap::makePolyShape(const std::vector<Point2f>& points, bool open, bool tempshape, int layerCol, float layerVal)
+int ShapeMap::makePolyShape(const std::vector<Point2f>& points, bool open, bool tempshape, const std::map<int,float> &extraAttributes)
 {
-    return makePolyShapeWithRef(points, open, getNextShapeKey(), tempshape, layerCol, layerVal);
+    return makePolyShapeWithRef(points, open, getNextShapeKey(), tempshape, extraAttributes);
 }
 
-int ShapeMap::makeShape(const SalaShape& poly, int override_shape_ref, int layerCol, float layerVal)
+int ShapeMap::makeShape(const SalaShape& poly, int override_shape_ref, const std::map<int,float> &extraAttributes)
 {
    // overridden shape cannot exist:
    if (override_shape_ref != -1 && m_shapes.find(override_shape_ref) != m_shapes.end()) {
@@ -483,8 +486,8 @@ int ShapeMap::makeShape(const SalaShape& poly, int override_shape_ref, int layer
    }
 
    int rowIndex = m_attributes.insertRow(shape_ref);
-   if ( layerCol != -1 ){
-       m_attributes.setValue(rowIndex, layerCol, layerVal);
+   for ( auto &attr : extraAttributes){
+       m_attributes.setValue(rowIndex, attr.first, attr.second);
    }
 
 

--- a/salalib/shapemap.h
+++ b/salalib/shapemap.h
@@ -281,14 +281,14 @@ public:
    int makePointShapeWithRef(const Point2f& point, int shape_ref, bool tempshape = false);
    int makePointShape(const Point2f& point, bool tempshape = false);
    // or a single line into a shape
-   int makeLineShapeWithRef(const Line& line, int shape_ref, bool through_ui = false, bool tempshape = false);
-   int makeLineShape(const Line& line, bool through_ui = false, bool tempshape = false);
+   int makeLineShapeWithRef(const Line& line, int shape_ref, bool through_ui = false, bool tempshape = false, int layerCol = -1, float layerVal = 0.0f);
+   int makeLineShape(const Line& line, bool through_ui = false, bool tempshape = false, int layerCol = -1, float layerVal = 0.0f);
    // or a polygon into a shape
-   int makePolyShapeWithRef(const std::vector<Point2f> &points, bool open, int shape_ref, bool tempshape = false);
-   int makePolyShape(const std::vector<Point2f> &points, bool open, bool tempshape = false);
+   int makePolyShapeWithRef(const std::vector<Point2f> &points, bool open, int shape_ref, bool tempshape = false, int layerCol = -1, float layerVal = 0.0f);
+   int makePolyShape(const std::vector<Point2f> &points, bool open, bool tempshape = false, int layerCol = -1, float layerVal = 0.0f);
 public:
    // or make a shape from a shape
-   int makeShape(const SalaShape& shape, int override_shape_ref = -1);
+   int makeShape(const SalaShape& shape, int override_shape_ref = -1, int layerCol = -1, float layerVal = 0.0f);
    // convert points to polygons
    bool convertPointsToPolys(double poly_radius, bool selected_only);
    // convert a selected pixels to a layer object (note, uses selection attribute on pixel, you must select to make this work):

--- a/salalib/shapemap.h
+++ b/salalib/shapemap.h
@@ -278,17 +278,17 @@ public:
    void init(int size, const QtRegion& r);
    int getNextShapeKey();
    // convert a single point into a shape
-   int makePointShapeWithRef(const Point2f& point, int shape_ref, bool tempshape = false);
-   int makePointShape(const Point2f& point, bool tempshape = false);
+   int makePointShapeWithRef(const Point2f& point, int shape_ref, bool tempshape = false, const std::map<int,float> &extraAttributes = std::map<int, float>());
+   int makePointShape(const Point2f& point, bool tempshape = false, const std::map<int,float> &extraAttributes = std::map<int, float>());
    // or a single line into a shape
-   int makeLineShapeWithRef(const Line& line, int shape_ref, bool through_ui = false, bool tempshape = false, int layerCol = -1, float layerVal = 0.0f);
-   int makeLineShape(const Line& line, bool through_ui = false, bool tempshape = false, int layerCol = -1, float layerVal = 0.0f);
+   int makeLineShapeWithRef(const Line& line, int shape_ref, bool through_ui = false, bool tempshape = false, const std::map<int,float> &extraAttributes = std::map<int, float>());
+   int makeLineShape(const Line& line, bool through_ui = false, bool tempshape = false, const std::map<int,float> &extraAttributes = std::map<int, float>());
    // or a polygon into a shape
-   int makePolyShapeWithRef(const std::vector<Point2f> &points, bool open, int shape_ref, bool tempshape = false, int layerCol = -1, float layerVal = 0.0f);
-   int makePolyShape(const std::vector<Point2f> &points, bool open, bool tempshape = false, int layerCol = -1, float layerVal = 0.0f);
+   int makePolyShapeWithRef(const std::vector<Point2f> &points, bool open, int shape_ref, bool tempshape = false, const std::map<int,float> &extraAttributes = std::map<int, float>());
+   int makePolyShape(const std::vector<Point2f> &points, bool open, bool tempshape = false, const std::map<int,float> &extraAttributes = std::map<int, float>());
 public:
    // or make a shape from a shape
-   int makeShape(const SalaShape& shape, int override_shape_ref = -1, int layerCol = -1, float layerVal = 0.0f);
+   int makeShape(const SalaShape& shape, int override_shape_ref = -1, const std::map<int,float> &extraAttributes = std::map<int,float>());
    // convert points to polygons
    bool convertPointsToPolys(double poly_radius, bool selected_only);
    // convert a selected pixels to a layer object (note, uses selection attribute on pixel, you must select to make this work):


### PR DESCRIPTION
Fix for ticket #198 - rejig a lot of axial map and segment map creation and copying code so that required attributes are copied over on creation of new elements (and their attribute row) to avoid having to copy data from one attribute table to another and relying that the row ordering is aligned.