### PR TITLE
Make sure closed polygons are also provided when getLines is called

### DIFF
--- a/salalib/shapemap.h
+++ b/salalib/shapemap.h
@@ -150,9 +150,12 @@ public:
        if (isLine()) {
           lines.push_back(getLine());
        }
-       else if (isPolyLine()) {
+       else if (isPolyLine() || isPolygon()) {
           for (size_t j = 0; j < m_points.size() - 1; j++) {
              lines.push_back(Line(m_points[j], m_points[j+1]));
+          }
+          if(isClosed()) {
+              lines.push_back(Line(m_points[m_points.size() - 1], m_points[0]));
           }
        }
        return lines;


### PR DESCRIPTION
This affects isovist creation which, without this change, does not "see" closed polygons