### PR TITLE
#230 No warnings in mgraph440

### DIFF
--- a/mgraph440/mgraph440.pro
+++ b/mgraph440/mgraph440.pro
@@ -10,9 +10,8 @@ CONFIG -= app_bundle
 TARGET = mgraph440
 TEMPLATE = lib
 
-# suppress warning about std::set<int> and pointer truncation - not going to fix bad legacy code in this library
-# as the whole point is to provide a legacy compatibility layer.
-win32: QMAKE_CXXFLAGS += -wd4800 -wd4311
+# suppress warning about std::set<int> on MSVC 2015
+win32: QMAKE_CXXFLAGS += -wd4800
 
 DEFINES += MGRAPH440_LIBRARY
 

--- a/mgraph440/mgraph440.pro
+++ b/mgraph440/mgraph440.pro
@@ -3,13 +3,16 @@ include(../defaults.pri)
 
 QT       -= qt
 QT -= gui
-CONFIG   -= qt
-
+CONFIG   -= qt warn_on
 
 CONFIG += staticlib c++11 console
 CONFIG -= app_bundle
 TARGET = mgraph440
 TEMPLATE = lib
+
+# suppress warning about std::set<int> and pointer truncation - not going to fix bad legacy code in this library
+# as the whole point is to provide a legacy compatibility layer.
+win32: QMAKE_CXXFLAGS += -wd4800 -wd4311
 
 DEFINES += MGRAPH440_LIBRARY
 

--- a/mgraph440/mgraph440.pro
+++ b/mgraph440/mgraph440.pro
@@ -5,7 +5,7 @@ QT       -= qt
 QT -= gui
 CONFIG   -= qt warn_on
 
-CONFIG += staticlib c++11 console
+CONFIG += staticlib c++11 console warn_off
 CONFIG -= app_bundle
 TARGET = mgraph440
 TEMPLATE = lib


### PR DESCRIPTION
Kick off the work to clean up warnings by suppressing all warning from the legacy code in mgraph440 - this is supposed to be legacy and we will not fix anything here.