### PR TITLE
Make the attribute map non-templated

### DIFF
--- a/salaTest/testattributetable.cpp
+++ b/salaTest/testattributetable.cpp
@@ -179,7 +179,7 @@ TEST_CASE("test attribute table")
 {
     using namespace dXreimpl;
 
-    AttributeTable<SerialisedPixelRef> table;
+    AttributeTable table;
 
     table.insertOrResetColumn("col1");
     table.getOrInsertColumn("col2");
@@ -194,18 +194,18 @@ TEST_CASE("test attribute table")
     REQUIRE(table.getColumn(3).getName() == "lcol2");
     REQUIRE(table.getColumn(3).isLocked());
 
-    table.addRow(SerialisedPixelRef(0));
-    REQUIRE(table.getRow(SerialisedPixelRef(0)).getValue("col1") == -1 );
-    table.getRow(SerialisedPixelRef(0)).setValue("col1", 1.2f );
-    REQUIRE(table.getRow(SerialisedPixelRef(0)).getValue("col1") == Approx(1.2f) );
-    REQUIRE(table.getRow(SerialisedPixelRef(0)).getValue(0) == Approx(1.2f) );
+    table.addRow(AttributeKey(0));
+    REQUIRE(table.getRow(AttributeKey(0)).getValue("col1") == -1 );
+    table.getRow(AttributeKey(0)).setValue("col1", 1.2f );
+    REQUIRE(table.getRow(AttributeKey(0)).getValue("col1") == Approx(1.2f) );
+    REQUIRE(table.getRow(AttributeKey(0)).getValue(0) == Approx(1.2f) );
 
-    REQUIRE(table.getRow(SerialisedPixelRef(0)).getValue("lcol2") == -1 );
-    table.getRow(SerialisedPixelRef(0)).setValue(3, 1.4f );
-    REQUIRE(table.getRow(SerialisedPixelRef(0)).getValue("lcol2") == Approx(1.4f) );
-    REQUIRE(table.getRow(SerialisedPixelRef(0)).getValue(3) == Approx(1.4f) );
+    REQUIRE(table.getRow(AttributeKey(0)).getValue("lcol2") == -1 );
+    table.getRow(AttributeKey(0)).setValue(3, 1.4f );
+    REQUIRE(table.getRow(AttributeKey(0)).getValue("lcol2") == Approx(1.4f) );
+    REQUIRE(table.getRow(AttributeKey(0)).getValue(3) == Approx(1.4f) );
 
-    REQUIRE_THROWS_AS(table.getRow(SerialisedPixelRef(0)).getValue(4), std::out_of_range);
+    REQUIRE_THROWS_AS(table.getRow(AttributeKey(0)).getValue(4), std::out_of_range);
 
     table.removeColumn(0);
     table.removeColumn(1);
@@ -215,34 +215,34 @@ TEST_CASE("test attribute table")
     REQUIRE(table.getColumn(1).getName() == "lcol2");
     REQUIRE(table.getColumnIndex("lcol2") == 1);
 
-    REQUIRE(table.getRow(SerialisedPixelRef(0)).getValue("col2") == -1.0 );
-    REQUIRE(table.getRow(SerialisedPixelRef(0)).getValue(0) == -1.0 );
-    REQUIRE(table.getRow(SerialisedPixelRef(0)).getValue("lcol2") == Approx(1.4f) );
-    REQUIRE(table.getRow(SerialisedPixelRef(0)).getValue(1) == Approx(1.4f) );
+    REQUIRE(table.getRow(AttributeKey(0)).getValue("col2") == -1.0 );
+    REQUIRE(table.getRow(AttributeKey(0)).getValue(0) == -1.0 );
+    REQUIRE(table.getRow(AttributeKey(0)).getValue("lcol2") == Approx(1.4f) );
+    REQUIRE(table.getRow(AttributeKey(0)).getValue(1) == Approx(1.4f) );
 
 
-    REQUIRE_THROWS_AS(table.getRow(SerialisedPixelRef(0)).getValue(2), std::out_of_range);
+    REQUIRE_THROWS_AS(table.getRow(AttributeKey(0)).getValue(2), std::out_of_range);
 
-    table.addRow(SerialisedPixelRef(1));
-    REQUIRE_THROWS_AS(table.getRow(SerialisedPixelRef(1)).getValue(2), std::out_of_range);
-    REQUIRE(table.getRow(SerialisedPixelRef(1)).getValue("col2") == -1.0 );
-    REQUIRE(table.getRow(SerialisedPixelRef(1)).getValue(0) == -1.0 );
-    REQUIRE(table.getRow(SerialisedPixelRef(1)).getValue("lcol2") == -1.0 );
-    REQUIRE(table.getRow(SerialisedPixelRef(1)).getValue(1) == -1.0 );
+    table.addRow(AttributeKey(1));
+    REQUIRE_THROWS_AS(table.getRow(AttributeKey(1)).getValue(2), std::out_of_range);
+    REQUIRE(table.getRow(AttributeKey(1)).getValue("col2") == -1.0 );
+    REQUIRE(table.getRow(AttributeKey(1)).getValue(0) == -1.0 );
+    REQUIRE(table.getRow(AttributeKey(1)).getValue("lcol2") == -1.0 );
+    REQUIRE(table.getRow(AttributeKey(1)).getValue(1) == -1.0 );
 
-    table.getRow(SerialisedPixelRef(1)).setValue(0, 2.4f);
-    table.getRow(SerialisedPixelRef(1)).setValue("lcol2", 2.6f);
-    REQUIRE(table.getRow(SerialisedPixelRef(1)).getValue("col2") == Approx(2.4) );
-    REQUIRE(table.getRow(SerialisedPixelRef(1)).getValue(1) == Approx(2.6) );
+    table.getRow(AttributeKey(1)).setValue(0, 2.4f);
+    table.getRow(AttributeKey(1)).setValue("lcol2", 2.6f);
+    REQUIRE(table.getRow(AttributeKey(1)).getValue("col2") == Approx(2.4) );
+    REQUIRE(table.getRow(AttributeKey(1)).getValue(1) == Approx(2.6) );
 
     size_t idx = table.getOrInsertColumn("col2");
     REQUIRE(idx == 0);
-    REQUIRE(table.getRow(SerialisedPixelRef(1)).getValue("col2") == Approx(2.4) );
+    REQUIRE(table.getRow(AttributeKey(1)).getValue("col2") == Approx(2.4) );
     REQUIRE(table.getColumn(0).getStats().max == Approx(2.4));
 
     idx = table.insertOrResetColumn("col2");
     REQUIRE(idx == 0);
-    REQUIRE(table.getRow(SerialisedPixelRef(1)).getValue("col2") == -1.0 );
+    REQUIRE(table.getRow(AttributeKey(1)).getValue("col2") == -1.0 );
     REQUIRE(table.getColumn(0).getStats().max == -1.0);
 
     size_t newColIndex = table.getOrInsertColumn("newCol");
@@ -251,7 +251,7 @@ TEST_CASE("test attribute table")
     REQUIRE(table.getColumnIndex("newCol") == 2);
     REQUIRE(table.getColumn(2).getName() == "newCol");
 
-    REQUIRE(table.getRow(SerialisedPixelRef(0)).getValue(2) == -1.0);
+    REQUIRE(table.getRow(AttributeKey(0)).getValue(2) == -1.0);
 
     table.renameColumn("col2", "col_foo");
     REQUIRE(table.getColumnName(0) == "col_foo");
@@ -260,9 +260,9 @@ TEST_CASE("test attribute table")
 
     REQUIRE_THROWS_AS(table.getColumnIndex("col2"), std::out_of_range);
 
-    table.getRow(0).setSelection(true);
+    table.getRow(AttributeKey(0)).setSelection(true);
 
-    REQUIRE(table.getRow(0).isSelected());
+    REQUIRE(table.getRow(AttributeKey(0)).isSelected());
     auto iter = table.begin();
     REQUIRE(iter->getRow().isSelected());
     ++iter;
@@ -286,49 +286,49 @@ TEST_CASE("test attribute table")
 TEST_CASE("Existing and non-existing rows")
 {
     using namespace dXreimpl;
-    AttributeTable<SerialisedPixelRef> table;
+    AttributeTable table;
     table.getOrInsertColumn("col1");
     table.getOrInsertColumn("col2");
-    table.addRow(0).setValue(0, 1.0f);
-    table.addRow(1).setValue(0, 0.5f);
-    table.addRow(2).setValue(0, 2.0f);
+    table.addRow(AttributeKey(0)).setValue(0, 1.0f);
+    table.addRow(AttributeKey(1)).setValue(0, 0.5f);
+    table.addRow(AttributeKey(2)).setValue(0, 2.0f);
 
-    const AttributeTable<SerialisedPixelRef>& constRef = table;
+    const AttributeTable& constRef = table;
 
-    table.getRow(0);
-    constRef.getRow(0);
-    REQUIRE_THROWS_AS(table.getRow(5), std::out_of_range);
-    REQUIRE_THROWS_AS(constRef.getRow(5), std::out_of_range);
+    table.getRow(AttributeKey(0));
+    constRef.getRow(AttributeKey(0));
+    REQUIRE_THROWS_AS(table.getRow(AttributeKey(5)), std::out_of_range);
+    REQUIRE_THROWS_AS(constRef.getRow(AttributeKey(5)), std::out_of_range);
 
-    REQUIRE( table.getRowPtr(1) != 0);
-    REQUIRE( constRef.getRowPtr(1) != 0);
+    REQUIRE( table.getRowPtr(AttributeKey(1)) != 0);
+    REQUIRE( constRef.getRowPtr(AttributeKey(1)) != 0);
 
-    REQUIRE( table.getRowPtr(5) == 0);
-    REQUIRE( constRef.getRowPtr(5) == 0);
+    REQUIRE( table.getRowPtr(AttributeKey(5)) == 0);
+    REQUIRE( constRef.getRowPtr(AttributeKey(5)) == 0);
 }
 
 TEST_CASE("normalised values"){
     using namespace dXreimpl;
-    AttributeTable<SerialisedPixelRef> table;
+    AttributeTable table;
     table.getOrInsertColumn("col1");
     table.getOrInsertColumn("col2");
-    table.addRow(0).setValue(0, 1.0f);
-    table.addRow(1).setValue(0, 0.5f);
-    table.addRow(2).setValue(0, 2.0f);
+    table.addRow(AttributeKey(0)).setValue(0, 1.0f);
+    table.addRow(AttributeKey(1)).setValue(0, 0.5f);
+    table.addRow(AttributeKey(2)).setValue(0, 2.0f);
 
-    REQUIRE(table.getRow(0).getNormalisedValue(1) == Approx(0.5f));
-    REQUIRE(table.getRow(0).getNormalisedValue(0) == Approx(0.33333f));
-    REQUIRE(table.getRow(1).getNormalisedValue(0) == Approx(0.0f));
-    REQUIRE(table.getRow(2).getNormalisedValue(0) == Approx(1.0f));
+    REQUIRE(table.getRow(AttributeKey(0)).getNormalisedValue(1) == Approx(0.5f));
+    REQUIRE(table.getRow(AttributeKey(0)).getNormalisedValue(0) == Approx(0.33333f));
+    REQUIRE(table.getRow(AttributeKey(1)).getNormalisedValue(0) == Approx(0.0f));
+    REQUIRE(table.getRow(AttributeKey(2)).getNormalisedValue(0) == Approx(1.0f));
 
-    table.addRow(3).setValue(1,1.0f);
+    table.addRow(AttributeKey(3)).setValue(1,1.0f);
 
-    REQUIRE(table.getRow(1).getNormalisedValue(1) == Approx(0.5f));
-    REQUIRE(table.getRow(3).getNormalisedValue(1) == Approx(0.5f));
+    REQUIRE(table.getRow(AttributeKey(1)).getNormalisedValue(1) == Approx(0.5f));
+    REQUIRE(table.getRow(AttributeKey(3)).getNormalisedValue(1) == Approx(0.5f));
 
-    table.getRow(0).setValue(1,1.1f);
-    REQUIRE(table.getRow(3).getNormalisedValue(1) == Approx(0.0f));
-    REQUIRE(table.getRow(1).getNormalisedValue(1) == Approx(-1.0f));
+    table.getRow(AttributeKey(0)).setValue(1,1.1f);
+    REQUIRE(table.getRow(AttributeKey(3)).getNormalisedValue(1) == Approx(0.0f));
+    REQUIRE(table.getRow(AttributeKey(1)).getNormalisedValue(1) == Approx(-1.0f));
 
 
 }
@@ -336,17 +336,17 @@ TEST_CASE("normalised values"){
 TEST_CASE("attibute table iterations")
 {
     using namespace dXreimpl;
-    AttributeTable<SerialisedPixelRef> table;
+    AttributeTable table;
 
     table.insertOrResetColumn("col1");
     table.getOrInsertColumn("col2");
 
-    auto& row = table.addRow(SerialisedPixelRef(0));
+    auto& row = table.addRow(AttributeKey(0));
     row.setValue(0, 0.5f);
-    auto& row2 = table.addRow(SerialisedPixelRef(1));
+    auto& row2 = table.addRow(AttributeKey(1));
     row2.setValue(0, 1.0f);
 
-    AttributeTable<SerialisedPixelRef>::iterator iter = table.begin();
+    AttributeTable::iterator iter = table.begin();
     REQUIRE((*iter).getKey().value == 0);
     REQUIRE(iter->getRow().getValue(0) == Approx(0.5));
     iter++;
@@ -361,10 +361,10 @@ TEST_CASE("attibute table iterations")
         item.getRow().setValue(1, 2.0f);
     }
 
-    REQUIRE(table.getRow(0).getValue(1) == Approx(2.0));
-    REQUIRE(table.getRow(1).getValue(1) == Approx(2.0));
+    REQUIRE(table.getRow(AttributeKey(0)).getValue(1) == Approx(2.0));
+    REQUIRE(table.getRow(AttributeKey(1)).getValue(1) == Approx(2.0));
 
-    const AttributeTable<SerialisedPixelRef>& const_table = table;
+    const AttributeTable& const_table = table;
 
     auto citer = const_table.begin();
     REQUIRE((*citer).getKey().value == 0);
@@ -378,9 +378,9 @@ TEST_CASE("attibute table iterations")
     REQUIRE(citer == cend);
     REQUIRE(citer == table.end());
 
-    AttributeTable<SerialisedPixelRef>::iterator foo(iter);
-    AttributeTable<SerialisedPixelRef>::const_iterator cfoo(iter);
-    AttributeTable<SerialisedPixelRef>::const_iterator ccfoo(citer);
+    AttributeTable::iterator foo(iter);
+    AttributeTable::const_iterator cfoo(iter);
+    AttributeTable::const_iterator ccfoo(citer);
 
     REQUIRE(iter == foo);
     REQUIRE(cfoo == iter);
@@ -395,8 +395,8 @@ TEST_CASE("attibute table iterations")
     ++foo;
     foo->getRow().setValue(1, 3.2f);
 
-    REQUIRE(table.getRow(0).getValue(1) == Approx(2.2));
-    REQUIRE(table.getRow(1).getValue(1) == Approx(3.2));
+    REQUIRE(table.getRow(AttributeKey(0)).getValue(1) == Approx(2.2));
+    REQUIRE(table.getRow(AttributeKey(1)).getValue(1) == Approx(3.2));
 }
 
 #include "salalib/attributes.h"
@@ -408,7 +408,7 @@ TEST_CASE("Attribute Table - serialisation")
     layerManager.addLayer("extra layer");
     REQUIRE(layerManager.getLayerIndex("extra layer") == 1);
 
-    dXreimpl::AttributeTable<dXreimpl::SerialisedPixelRef> newTable;
+    dXreimpl::AttributeTable newTable;
     size_t colIndex1 = newTable.getOrInsertColumn("foo", "foo formula");
     size_t colIndex2 = newTable.getOrInsertColumn("bar");
 
@@ -426,8 +426,8 @@ TEST_CASE("Attribute Table - serialisation")
     newTable.getColumn(colIndex2).setDisplayParams(barDp);
     newTable.setDisplayParams(overAllDp);
 
-    auto& row = newTable.addRow(0);
-    auto& row2 = newTable.addRow(10);
+    auto& row = newTable.addRow(dXreimpl::AttributeKey(0));
+    auto& row2 = newTable.addRow(dXreimpl::AttributeKey(10));
 
     row.setValue(0,1.0f);
     row.setValue(1,2.0f);
@@ -450,18 +450,18 @@ TEST_CASE("Attribute Table - serialisation")
         newTable.write(outfile, layerManager);
     }
 
-    dXreimpl::AttributeTable<dXreimpl::SerialisedPixelRef> copyTable;
+    dXreimpl::AttributeTable copyTable;
     LayerManagerImpl copyLayerManager;
     {
         std::ifstream infile(newTableFile.Filename());
         copyTable.read(infile, copyLayerManager, METAGRAPH_VERSION);
     }
 
-    auto& copyRow = copyTable.getRow(0);
+    auto& copyRow = copyTable.getRow(dXreimpl::AttributeKey(0));
     REQUIRE(copyRow.getValue(0) == Approx(1.0f));
     REQUIRE(copyRow.getValue(1) == Approx(2.0f));
 
-    auto& copyRow2 = copyTable.getRow(10);
+    auto& copyRow2 = copyTable.getRow(dXreimpl::AttributeKey(10));
     REQUIRE(copyRow2.getValue(0) == Approx(11.0f));
     REQUIRE(copyRow2.getValue(1) == Approx(12.0f));
 
@@ -518,18 +518,18 @@ TEST_CASE("Attribute Table - serialisation")
     }
 
 
-    dXreimpl::AttributeTable<dXreimpl::SerialisedPixelRef> roundTripTable;
+    dXreimpl::AttributeTable roundTripTable;
     LayerManagerImpl roundTripManager;
     {
         std::ifstream infile(legacyTableFile.Filename());
         roundTripTable.read(infile, roundTripManager, METAGRAPH_VERSION);
     }
 
-    auto& roundtripRow = roundTripTable.getRow(0);
+    auto& roundtripRow = roundTripTable.getRow(dXreimpl::AttributeKey(0));
     REQUIRE(roundtripRow.getValue(0) == Approx(1.0f));
     REQUIRE(roundtripRow.getValue(1) == Approx(2.0f));
 
-    auto& roundtripRow2 = roundTripTable.getRow(10);
+    auto& roundtripRow2 = roundTripTable.getRow(dXreimpl::AttributeKey(10));
     REQUIRE(roundtripRow2.getValue(0) == Approx(11.0f));
     REQUIRE(roundtripRow2.getValue(1) == Approx(12.0f));
 

--- a/salaTest/testattributetablehelpers.cpp
+++ b/salaTest/testattributetablehelpers.cpp
@@ -23,7 +23,7 @@ TEST_CASE("push to layer")
     using namespace dXreimpl;
     using namespace fakeit;
     Mock<LayerManager> layMan;
-    AttributeTable<SerialisedPixelRef> table;
+    AttributeTable table;
     When(Method(layMan,addLayer)).Do([](const std::string &name)->size_t{REQUIRE(name == "testlayer"); return 1;});
     When(Method(layMan,getKey).Using(1)).AlwaysReturn(2);
     When(Method(layMan,isVisible).Using(1)).AlwaysReturn(true);
@@ -32,10 +32,10 @@ TEST_CASE("push to layer")
     table.insertOrResetColumn("col1");
     table.getOrInsertColumn("col2");
 
-    auto& row = table.addRow(SerialisedPixelRef(0));
+    auto& row = table.addRow(AttributeKey(0));
     row.setValue(0, 0.5f);
     row.setSelection(true);
-    auto& row2 = table.addRow(SerialisedPixelRef(1));
+    auto& row2 = table.addRow(AttributeKey(1));
     row2.setValue(0, 1.0f);
 
    pushSelectionToLayer(table, layMan.get(), "testlayer");

--- a/salaTest/testattributetableindex.cpp
+++ b/salaTest/testattributetableindex.cpp
@@ -19,21 +19,21 @@
 TEST_CASE("Check index creation")
 {
     using namespace dXreimpl;
-    AttributeTable<SerialisedPixelRef> table;
+    AttributeTable table;
     table.getOrInsertColumn("col1");
     table.getOrInsertColumn("col2");
 
-    auto& row0 = table.addRow(0);
-    auto& row1 = table.addRow(1);
-    auto& row2 = table.addRow(2);
-    auto& row3 = table.addRow(3);
+    auto& row0 = table.addRow(AttributeKey(0));
+    auto& row1 = table.addRow(AttributeKey(1));
+    auto& row2 = table.addRow(AttributeKey(2));
+    auto& row3 = table.addRow(AttributeKey(3));
 
     row0.setValue(0, 10.0);
     row1.setValue(0, 8.5);
     row2.setValue(0, 11.0);
     row3.setValue(0, 4.5);
 
-    auto index = makeAttributeIndex<AttributeIndexItem<SerialisedPixelRef>>(table, 0);
+    auto index = makeAttributeIndex(table, 0);
     REQUIRE(index.size() == 4);
     REQUIRE(index[0].key.value == 3);
     REQUIRE(index[1].key.value == 1);
@@ -41,6 +41,6 @@ TEST_CASE("Check index creation")
     REQUIRE(index[3].key.value == 2);
 
     index[3].mutable_row->setValue(1, 1.5);
-    REQUIRE(table.getRow(2).getValue(1) == Approx(1.5));
+    REQUIRE(table.getRow(AttributeKey(2)).getValue(1) == Approx(1.5));
 }
 

--- a/salaTest/testattributetableview.cpp
+++ b/salaTest/testattributetableview.cpp
@@ -18,12 +18,12 @@
 
 TEST_CASE("Test Attribute view"){
     using namespace dXreimpl;
-    AttributeTable<SerialisedPixelRef> table;
+    AttributeTable table;
 
     table.insertOrResetColumn("foo");
     table.insertOrResetColumn("bar");
-    table.addRow(0).setValue(0,1.0f).setValue(1, 1.1f);
-    table.addRow(7).setValue(0,0.7f).setValue(1,1.7f);
+    table.addRow(AttributeKey(0)).setValue(0,1.0f).setValue(1, 1.1f);
+    table.addRow(AttributeKey(7)).setValue(0,0.7f).setValue(1,1.7f);
 
     AttributeTableView view(table);
     view.setDisplayColIndex(0);
@@ -36,15 +36,15 @@ TEST_CASE("Test Attribute view"){
     REQUIRE(&view.getDisplayParams() == &table.getColumn(0).getDisplayParams());
 
 
-    table.addRow(3);
+    table.addRow(AttributeKey(3));
     view.setDisplayColIndex(-1);
-    REQUIRE(view.getNormalisedValue(3, table.getRow(3)) == Approx(3.0/7));
+    REQUIRE(view.getNormalisedValue(AttributeKey(3), table.getRow(AttributeKey(3))) == Approx(3.0/7));
     REQUIRE(view.getConstTableIndex().size() == 3);
 
     REQUIRE(&table.getDisplayParams() == &view.getDisplayParams());
 
     view.setDisplayColIndex(-2);
-    REQUIRE(view.getNormalisedValue(3, table.getRow(3)) == Approx(3.0/7));
+    REQUIRE(view.getNormalisedValue(AttributeKey(3), table.getRow(AttributeKey(3))) == Approx(3.0/7));
     REQUIRE(view.getConstTableIndex().empty());
 
     REQUIRE(&table.getDisplayParams() == &view.getDisplayParams());
@@ -55,12 +55,12 @@ TEST_CASE("Test Attribute view"){
 TEST_CASE("Test attribute table handle")
 {
     using namespace  dXreimpl;
-    AttributeTable<SerialisedPixelRef> table;
+    AttributeTable table;
 
     table.insertOrResetColumn("foo");
     table.insertOrResetColumn("bar");
-    table.addRow(0).setValue(0,1.0f).setValue(1, 1.1f);
-    table.addRow(7).setValue(0,0.7f).setValue(1,1.7f);
+    table.addRow(AttributeKey(0)).setValue(0,1.0f).setValue(1, 1.1f);
+    table.addRow(AttributeKey(7)).setValue(0,0.7f).setValue(1,1.7f);
 
     AttributeTableHandle handle(table);
     handle.setDisplayColIndex(0);
@@ -71,7 +71,7 @@ TEST_CASE("Test attribute table handle")
 
     handle.getTableIndex().front().mutable_row->setValue(0, 0.8f);
 
-    REQUIRE(table.getRow(7).getValue(0) == Approx(0.8));
+    REQUIRE(table.getRow(AttributeKey(7)).getValue(0) == Approx(0.8));
 
     handle.setDisplayColIndex(-1);
     REQUIRE(handle.getTableIndex().size() == 2);

--- a/salalib/attributetable.cpp
+++ b/salalib/attributetable.cpp
@@ -401,7 +401,7 @@ namespace  dXreimpl {
             stream.read((char *)&rowkey, sizeof(rowkey));
             auto row = std::unique_ptr<AttributeRowImpl>(new AttributeRowImpl(*this));
             row->read(stream, METAGRAPH_VERSION);
-            m_rows.insert(std::make_pair(rowkey,std::move(row)));
+            m_rows.insert(std::make_pair(AttributeKey(rowkey),std::move(row)));
         }
 
         // ref column display params

--- a/salalib/attributetable.cpp
+++ b/salalib/attributetable.cpp
@@ -21,206 +21,461 @@
 
 #include <sstream>
 
+namespace  dXreimpl {
 
-const std::string &dXreimpl::AttributeColumnImpl::getName() const
-{
-    return m_name;
-}
 
-bool dXreimpl::AttributeColumnImpl::isLocked() const
-{
-    return m_locked;
-}
 
-void dXreimpl::AttributeColumnImpl::setLock(bool lock)
-{
-    m_locked = lock;
-}
-
-bool dXreimpl::AttributeColumnImpl::isHidden() const
-{
-    return m_hidden;
-}
-
-void dXreimpl::AttributeColumnImpl::setHidden(bool hidden)
-{
-    m_hidden = hidden;
-}
-
-const std::string &dXreimpl::AttributeColumnImpl::getFormula() const
-{
-    return m_formula;
-}
-
-const dXreimpl::AttributeColumnStats &dXreimpl::AttributeColumnImpl::getStats() const
-{
-    return m_stats;
-}
-
-void dXreimpl::AttributeColumnImpl::updateStats(float val, float oldVal) const
-{
-    if (m_stats.total < 0)
+    const std::string &AttributeColumnImpl::getName() const
     {
-        m_stats.total = val;
+        return m_name;
     }
-    else
+
+    bool AttributeColumnImpl::isLocked() const
     {
-        m_stats.total += val;
-        m_stats.total -= oldVal;
+        return m_locked;
     }
-    if (val > m_stats.max)
+
+    void AttributeColumnImpl::setLock(bool lock)
     {
-        m_stats.max = val;
+        m_locked = lock;
     }
-    if (m_stats.min < 0 || val < m_stats.min)
+
+    bool AttributeColumnImpl::isHidden() const
     {
+        return m_hidden;
+    }
+
+    void AttributeColumnImpl::setHidden(bool hidden)
+    {
+        m_hidden = hidden;
+    }
+
+    const std::string &AttributeColumnImpl::getFormula() const
+    {
+        return m_formula;
+    }
+
+    const AttributeColumnStats &AttributeColumnImpl::getStats() const
+    {
+        return m_stats;
+    }
+
+    void AttributeColumnImpl::updateStats(float val, float oldVal) const
+    {
+        if (m_stats.total < 0)
+        {
+            m_stats.total = val;
+        }
+        else
+        {
+            m_stats.total += val;
+            m_stats.total -= oldVal;
+        }
+        if (val > m_stats.max)
+        {
+            m_stats.max = val;
+        }
+        if (m_stats.min < 0 || val < m_stats.min)
+        {
+            m_stats.min = val;
+        }
+    }
+
+    void AttributeColumnImpl::setName(const std::string &name)
+    {
+        m_name = name;
+    }
+
+    size_t AttributeColumnImpl::read(std::istream &stream, int version)
+    {
+        m_name = dXstring::readString(stream);
+        float val;
+        stream.read((char *)&val, sizeof(float));
         m_stats.min = val;
+        stream.read((char *)&val, sizeof(float));
+        m_stats.max = val;
+        stream.read((char *)&m_stats.total, sizeof(double));
+        int physical_column;
+        stream.read((char *)&physical_column, sizeof(int)); // physical column is obsolete
+        stream.read((char *)&m_hidden, sizeof(bool));
+        stream.read((char *)&m_locked, sizeof(bool));
+
+        stream.read((char*)&m_displayParams,sizeof(DisplayParams));
+        m_formula = dXstring::readString(stream);
+        return physical_column;
     }
-}
 
-void dXreimpl::AttributeColumnImpl::setName(const std::string &name)
-{
-    m_name = name;
-}
-
-size_t dXreimpl::AttributeColumnImpl::read(std::istream &stream, int version)
-{
-    m_name = dXstring::readString(stream);
-    float val;
-    stream.read((char *)&val, sizeof(float));
-    m_stats.min = val;
-    stream.read((char *)&val, sizeof(float));
-    m_stats.max = val;
-    stream.read((char *)&m_stats.total, sizeof(double));
-    int physical_column;
-    stream.read((char *)&physical_column, sizeof(int)); // physical column is obsolete
-    stream.read((char *)&m_hidden, sizeof(bool));
-    stream.read((char *)&m_locked, sizeof(bool));
-
-    stream.read((char*)&m_displayParams,sizeof(DisplayParams));
-    m_formula = dXstring::readString(stream);
-    return physical_column;
-}
-
-void dXreimpl::AttributeColumnImpl::write(std::ostream &stream, int physicalCol)
-{
-    dXstring::writeString(stream, m_name);
-    float min = (float)m_stats.min;
-    float max = (float)m_stats.max;
-    stream.write((char *)&min, sizeof(float));
-    stream.write((char *)&max, sizeof(float));
-    stream.write((char *)&m_stats.total, sizeof(m_stats.total));
-    stream.write((char *)&physicalCol, sizeof(int));
-    stream.write((char *)&m_hidden, sizeof(bool));
-    stream.write((char *)&m_locked, sizeof(bool));
-    stream.write((char *)&m_displayParams, sizeof(DisplayParams));
-    dXstring::writeString(stream, m_formula);
-
-}
-
-
-// AttributeRow implementation
-float dXreimpl::AttributeRowImpl::getValue(const std::string &column) const
-{
-    return getValue(m_colManager.getColumnIndex(column));
-}
-
-float dXreimpl::AttributeRowImpl::getValue(size_t index) const
-{
-    checkIndex(index);
-    return m_data[index];
-}
-
-float dXreimpl::AttributeRowImpl::getNormalisedValue(size_t index) const
-{
-    checkIndex(index);
-    auto& colStats = m_colManager.getColumn(index).getStats();
-    if (colStats.max == colStats.min)
+    void AttributeColumnImpl::write(std::ostream &stream, int physicalCol)
     {
-        return 0.5f;
+        dXstring::writeString(stream, m_name);
+        float min = (float)m_stats.min;
+        float max = (float)m_stats.max;
+        stream.write((char *)&min, sizeof(float));
+        stream.write((char *)&max, sizeof(float));
+        stream.write((char *)&m_stats.total, sizeof(m_stats.total));
+        stream.write((char *)&physicalCol, sizeof(int));
+        stream.write((char *)&m_hidden, sizeof(bool));
+        stream.write((char *)&m_locked, sizeof(bool));
+        stream.write((char *)&m_displayParams, sizeof(DisplayParams));
+        dXstring::writeString(stream, m_formula);
+
     }
-    return  m_data[index] < 0 ? -1.0f : float((m_data[index] - colStats.min)/(colStats.max - colStats.min));
-}
 
-dXreimpl::AttributeRow& dXreimpl::AttributeRowImpl::setValue(const std::string &column, float value)
-{
-    return setValue(m_colManager.getColumnIndex(column), value);
-}
 
-dXreimpl::AttributeRow& dXreimpl::AttributeRowImpl::setValue(size_t index, float value)
-{
-    checkIndex(index);
-    float oldVal = m_data[index];
-    m_data[index] = value;
-    if (oldVal < 0.0f)
+    // AttributeRow implementation
+    float AttributeRowImpl::getValue(const std::string &column) const
     {
-        oldVal = 0.0f;
+        return getValue(m_colManager.getColumnIndex(column));
     }
-    m_colManager.getColumn(index).updateStats(value, oldVal);
-    return *this;
-}
 
-dXreimpl::AttributeRow& dXreimpl::AttributeRowImpl::setSelection(bool selected)
-{
-    m_selected = selected;
-    return *this;
-}
-
-bool dXreimpl::AttributeRowImpl::isSelected() const
-{
-    return m_selected;
-}
-
-void dXreimpl::AttributeRowImpl::addColumn()
-{
-    m_data.push_back(-1);
-}
-
-void dXreimpl::AttributeRowImpl::removeColumn(size_t index)
-{
-    checkIndex(index);
-    m_data.erase(m_data.begin() + index);
-}
-
-void dXreimpl::AttributeRowImpl::read(std::istream &stream, int version)
-{
-    stream.read((char *)&m_layerKey, sizeof(m_layerKey));
-    dXreadwrite::readIntoVector(stream, m_data);
-}
-
-void dXreimpl::AttributeRowImpl::write(std::ostream &stream)
-{
-    stream.write((char *)&m_layerKey, sizeof(m_layerKey));
-    dXreadwrite::writeVector(stream, m_data);
-}
-
-void dXreimpl::AttributeRowImpl::checkIndex(size_t index) const
-{
-    if( index >= m_data.size())
+    float AttributeRowImpl::getValue(size_t index) const
     {
-        throw std::out_of_range("AttributeColumn index out of range");
+        checkIndex(index);
+        return m_data[index];
     }
-}
 
-
-
-dXreimpl::AttributeRow &dXreimpl::AttributeRowImpl::incrValue(size_t index, float value)
-{
-    checkIndex(index);
-    float val = m_data[index];
-    if ( val < 0)
+    float AttributeRowImpl::getNormalisedValue(size_t index) const
     {
-        setValue(index, value);
+        checkIndex(index);
+        auto& colStats = m_colManager.getColumn(index).getStats();
+        if (colStats.max == colStats.min)
+        {
+            return 0.5f;
+        }
+        return  m_data[index] < 0 ? -1.0f : float((m_data[index] - colStats.min)/(colStats.max - colStats.min));
     }
-    else
+
+    AttributeRow& AttributeRowImpl::setValue(const std::string &column, float value)
     {
-        setValue(index, val + value);
+        return setValue(m_colManager.getColumnIndex(column), value);
     }
-    return *this;
-}
+
+    AttributeRow& AttributeRowImpl::setValue(size_t index, float value)
+    {
+        checkIndex(index);
+        float oldVal = m_data[index];
+        m_data[index] = value;
+        if (oldVal < 0.0f)
+        {
+            oldVal = 0.0f;
+        }
+        m_colManager.getColumn(index).updateStats(value, oldVal);
+        return *this;
+    }
+
+    AttributeRow& AttributeRowImpl::setSelection(bool selected)
+    {
+        m_selected = selected;
+        return *this;
+    }
+
+    bool AttributeRowImpl::isSelected() const
+    {
+        return m_selected;
+    }
+
+    void AttributeRowImpl::addColumn()
+    {
+        m_data.push_back(-1);
+    }
+
+    void AttributeRowImpl::removeColumn(size_t index)
+    {
+        checkIndex(index);
+        m_data.erase(m_data.begin() + index);
+    }
+
+    void AttributeRowImpl::read(std::istream &stream, int version)
+    {
+        stream.read((char *)&m_layerKey, sizeof(m_layerKey));
+        dXreadwrite::readIntoVector(stream, m_data);
+    }
+
+    void AttributeRowImpl::write(std::ostream &stream)
+    {
+        stream.write((char *)&m_layerKey, sizeof(m_layerKey));
+        dXreadwrite::writeVector(stream, m_data);
+    }
+
+    void AttributeRowImpl::checkIndex(size_t index) const
+    {
+        if( index >= m_data.size())
+        {
+            throw std::out_of_range("AttributeColumn index out of range");
+        }
+    }
 
 
-dXreimpl::AttributeRow &dXreimpl::AttributeRowImpl::incrValue(const std::string &colName, float value)
-{
-    return incrValue(m_colManager.getColumnIndex(colName), value);
+
+    AttributeRow &AttributeRowImpl::incrValue(size_t index, float value)
+    {
+        checkIndex(index);
+        float val = m_data[index];
+        if ( val < 0)
+        {
+            setValue(index, value);
+        }
+        else
+        {
+            setValue(index, val + value);
+        }
+        return *this;
+    }
+
+
+    AttributeRow &AttributeRowImpl::incrValue(const std::string &colName, float value)
+    {
+        return incrValue(m_colManager.getColumnIndex(colName), value);
+    }
+
+    AttributeRow &AttributeTable::getRow(const AttributeKey &key)
+    {
+        auto* row = getRowPtr(key);
+        if (row == 0)
+        {
+            throw std::out_of_range("Invalid row key");
+        }
+        return *row;
+    }
+
+    const AttributeRow& AttributeTable::getRow(const AttributeKey &key) const
+    {
+        auto* row = getRowPtr(key);
+        if (row == 0)
+        {
+            throw std::out_of_range("Invalid row key");
+        }
+        return *row;
+    }
+
+    AttributeRow *AttributeTable::getRowPtr(const AttributeKey &key)
+    {
+        auto iter = m_rows.find(key);
+        if (iter == m_rows.end())
+        {
+            return 0;
+        }
+        return iter->second.get();
+    }
+
+    const AttributeRow *AttributeTable::getRowPtr(const AttributeKey &key) const
+    {
+        auto iter = m_rows.find(key);
+        if (iter == m_rows.end())
+        {
+            return 0;
+        }
+        return iter->second.get();
+    }
+
+    AttributeRow &AttributeTable::addRow(const AttributeKey &key)
+    {
+        auto iter = m_rows.find(key);
+        if (iter != m_rows.end())
+        {
+            throw new std::invalid_argument("Duplicate key");
+        }
+        auto res = m_rows.insert(std::make_pair(key, std::unique_ptr<AttributeRowImpl>(new AttributeRowImpl(*this))));
+        return *res.first->second;
+    }
+
+    AttributeColumn &AttributeTable::getColumn(size_t index)
+    {
+        checkColumnIndex(index);
+        return m_columns[index];
+    }
+
+    size_t AttributeTable::insertOrResetColumn(const std::string &columnName, const std::string &formula)
+    {
+        auto iter = m_columnMapping.find(columnName);
+        if (iter == m_columnMapping.end())
+        {
+            return addColumnInternal(columnName, formula);
+        }
+
+        // it exists - we need to reset it
+        m_columns[iter->second].m_stats = AttributeColumnStats();
+        m_columns[iter->second].setLock(false);
+        for (auto& row : m_rows)
+        {
+            row.second->setValue(iter->second, -1.0f);
+        }
+        return iter->second;
+    }
+
+    size_t AttributeTable::insertOrResetLockedColumn(const std::string &columnName, const std::string &formula)
+    {
+        size_t index = insertOrResetColumn(columnName, formula);
+        m_columns[index].setLock(true);
+        return index;
+    }
+
+    size_t AttributeTable::getOrInsertColumn(const std::string &columnName, const std::string &formula)
+    {
+        auto iter = m_columnMapping.find(columnName);
+        if ( iter != m_columnMapping.end())
+        {
+            return iter->second;
+        }
+        return addColumnInternal(columnName, formula);
+    }
+
+    size_t AttributeTable::getOrInsertLockedColumn(const std::string &columnName, const std::string &formula)
+    {
+        size_t index = getOrInsertColumn(columnName, formula);
+        m_columns[index].setLock(true);
+        return index;
+    }
+
+    void AttributeTable::removeColumn(size_t colIndex)
+    {
+        checkColumnIndex(colIndex);
+        const std::string& name = m_columns[colIndex].getName();
+        auto iter = m_columnMapping.find(name);
+        m_columnMapping.erase(iter);
+        for (auto& elem : m_columnMapping)
+        {
+            if (elem.second > colIndex)
+            {
+                elem.second--;
+            }
+        }
+        m_columns.erase(m_columns.begin()+colIndex);
+        for (auto& row : m_rows)
+        {
+            row.second->removeColumn(colIndex);
+        }
+    }
+
+    void AttributeTable::renameColumn(const std::string &oldName, const std::string &newName)
+    {
+        auto iter = m_columnMapping.find(oldName);
+        if (iter == m_columnMapping.end())
+        {
+            throw std::out_of_range("Invalid column name");
+        }
+
+        size_t colIndex = iter->second;
+        m_columns[colIndex].setName(newName);
+        m_columnMapping.erase(iter);
+        m_columnMapping[newName] = colIndex;
+
+    }
+
+    void AttributeTable::deselectAllRows()
+    {
+        for (auto& row : m_rows)
+        {
+            row.second->setSelection(false);
+        }
+    }
+
+    void AttributeTable::setDisplayParamsForAllAttributes(const DisplayParams &params)
+    {
+        for (auto& col: m_columns)
+        {
+            col.setDisplayParams(params);
+        }
+
+    }
+
+    void AttributeTable::read(std::istream &stream, LayerManager &layerManager, int version)
+    {
+        layerManager.read(stream);
+        int colcount;
+        stream.read((char *)&colcount, sizeof(colcount));
+        std::map<size_t, AttributeColumnImpl> tmp;
+        for (int j = 0; j < colcount; j++) {
+            AttributeColumnImpl col("");
+            tmp[col.read(stream, METAGRAPH_VERSION)] = col;
+        }
+        for (auto & c : tmp)
+        {
+            m_columnMapping[c.second.getName()] = m_columns.size();
+            m_columns.push_back(c.second);
+        }
+
+        int rowcount, rowkey;
+        stream.read((char *)&rowcount, sizeof(rowcount));
+        for (int i = 0; i < rowcount; i++) {
+            stream.read((char *)&rowkey, sizeof(rowkey));
+            auto row = std::unique_ptr<AttributeRowImpl>(new AttributeRowImpl(*this));
+            row->read(stream, METAGRAPH_VERSION);
+            m_rows.insert(std::make_pair(rowkey,std::move(row)));
+        }
+
+        // ref column display params
+        stream.read((char *)&m_displayParams,sizeof(DisplayParams));
+    }
+
+    void AttributeTable::write(std::ostream &stream, const LayerManager &layerManager)
+    {
+        layerManager.write(stream);
+        int colCount = (int)m_columns.size();
+        stream.write((char *)&colCount, sizeof(int));
+        for (size_t i = 0; i < m_columns.size(); ++i)
+        {
+            m_columns[i].write(stream, (int)i);
+        }
+
+        int rowcount = (int)m_rows.size();
+        stream.write((char *)&rowcount, sizeof(int));
+        for ( auto &kvp : m_rows)
+        {
+            kvp.first.write(stream);
+            kvp.second->write(stream);
+        }
+        stream.write((const char *)&m_displayParams, sizeof(DisplayParams));
+    }
+
+    size_t AttributeTable::getColumnIndex(const std::string &name) const
+    {
+        auto iter = m_columnMapping.find(name);
+        if (iter == m_columnMapping.end())
+        {
+            std::stringstream message;
+            message << "Unknown column name " << name;
+            throw std::out_of_range(message.str());
+        }
+        return iter->second;
+
+    }
+
+
+    const AttributeColumn &AttributeTable::getColumn(size_t index) const
+    {
+        checkColumnIndex(index);
+        return m_columns[index];
+    }
+
+    const std::string &AttributeTable::getColumnName(size_t index) const
+    {
+        checkColumnIndex(index);
+        return m_columns[index].getName();
+    }
+
+    size_t AttributeTable::getNumColumns() const
+    {
+        return m_columns.size();
+    }
+
+    void AttributeTable::checkColumnIndex(size_t index) const
+    {
+        if (index >= m_columns.size())
+        {
+            throw std::out_of_range("ColumnIndex out of range");
+        }
+    }
+
+    size_t AttributeTable::addColumnInternal(const std::string &name, const std::string &formula)
+    {
+        size_t colIndex = m_columns.size();
+        m_columns.push_back(AttributeColumnImpl(name, formula));
+        m_columnMapping[name] = colIndex;
+        for (auto& elem : m_rows)
+        {
+            elem.second->addColumn();
+        }
+        return colIndex;
+    }
 }

--- a/salalib/attributetable.h
+++ b/salalib/attributetable.h
@@ -193,18 +193,18 @@ namespace dXreimpl
     };
 
     ///
-    /// \brief Small struct to make a serialised pixel ref distinguishable from an int
+    /// \brief Small struct to make an attribute key distinguishable from an int
     /// PixelRefs are serialised into an int (2 bytes x, 2 bytes y) for historic reason. This seems dangerous
-    /// and confusing as these are by no means inices, but look the same to the compiler and the reader.
+    /// and confusing as these are by no means indices, but look the same to the compiler and the reader.
     /// This struct should disambiguate this...
     ///
-    struct SerialisedPixelRef
+    struct AttributeKey
     {
-        SerialisedPixelRef(int val) : value(val)
+        explicit AttributeKey(int val) : value(val)
         {}
         int value;
 
-        bool operator < (const SerialisedPixelRef& other ) const
+        bool operator < (const AttributeKey& other ) const
         {
             return value < other.value;
         }
@@ -222,9 +222,8 @@ namespace dXreimpl
 
     ///
     /// AttributeTable
-    /// Templated on the RowKeyType so we can switch that out easily, I am not to happy with the current one...
     ///
-    template<typename RowKeyType> class AttributeTable : public AttributeColumnManager
+    class AttributeTable : public AttributeColumnManager
     {
         // AttributeTable "interface" - the actual table handling
     public:
@@ -237,35 +236,35 @@ namespace dXreimpl
         /// \param key of the row
         /// \return reference to row, throws if key not found
         ///
-        AttributeRow& getRow(const RowKeyType& key );
+        AttributeRow& getRow(const AttributeKey& key );
 
         ///
         /// \brief Get a row const reference
         /// \param key of the row
         /// \return const reference to row, throws if key not found
         ///
-        const AttributeRow& getRow(const RowKeyType& key) const;
+        const AttributeRow& getRow(const AttributeKey& key) const;
 
         ///
         /// \brief Get a row pointer
         /// \param key of the row
         /// \return pointer to row, null if key not found
         ///
-        AttributeRow* getRowPtr(const RowKeyType& key);
+        AttributeRow* getRowPtr(const AttributeKey& key);
 
         ///
         /// \brief Get a row const pointer
         /// \param key of the row
         /// \return const pointer to row, null if key not found
         ///
-        const AttributeRow* getRowPtr(const RowKeyType& key)const;
-        AttributeRow &addRow(const RowKeyType& key);
+        const AttributeRow* getRowPtr(const AttributeKey& key)const;
+        AttributeRow &addRow(const AttributeKey& key);
         AttributeColumn& getColumn(size_t index);
         size_t insertOrResetColumn(const std::string& columnName, const std::string &formula = std::string());
         size_t insertOrResetLockedColumn(const std::string& columnName, const std::string &formula = std::string());
         size_t getOrInsertColumn(const std::string& columnName, const std::string &formula = std::string());
         size_t getOrInsertLockedColumn(const std::string& columnName, const std::string &formula = std::string());
-        void removeRow(const RowKeyType& key);
+        void removeRow(const AttributeKey& key);
         void removeColumn(size_t colIndex);
         void renameColumn(const std::string& oldName, const std::string& newName);
         size_t getNumRows() const { return m_rows.size(); }
@@ -284,7 +283,7 @@ namespace dXreimpl
         virtual size_t getNumColumns() const;
 
     private:
-        typedef std::map<RowKeyType, std::unique_ptr<AttributeRowImpl>> StorageType;
+        typedef std::map<AttributeKey, std::unique_ptr<AttributeRowImpl>> StorageType;
         StorageType m_rows;
         std::map<std::string, size_t> m_columnMapping;
         std::vector<AttributeColumnImpl> m_columns;
@@ -308,7 +307,7 @@ namespace dXreimpl
         class iterator_item
         {
         public:
-            virtual const RowKeyType& getKey() const = 0;
+            virtual const AttributeKey& getKey() const = 0;
             virtual const AttributeRow& getRow() const = 0;
             virtual AttributeRow& getRow() = 0;
             virtual ~iterator_item(){}
@@ -331,7 +330,7 @@ namespace dXreimpl
             }
 
 
-            const RowKeyType& getKey() const
+            const AttributeKey& getKey() const
             {
                 return m_iter->first;
             }
@@ -437,278 +436,5 @@ namespace dXreimpl
         }
     };
 
-// Below here is the implementation of AttributeTable methods - needs to be header only as it is templated.
-
-    template<class RowKeyType>
-    AttributeRow &AttributeTable<RowKeyType>::getRow(const RowKeyType &key)
-    {
-        auto* row = getRowPtr(key);
-        if (row == 0)
-        {
-            throw std::out_of_range("Invalid row key");
-        }
-        return *row;
-    }
-
-    template<class RowKeyType>
-    const AttributeRow& AttributeTable<RowKeyType>::getRow(const RowKeyType &key) const
-    {
-        auto* row = getRowPtr(key);
-        if (row == 0)
-        {
-            throw std::out_of_range("Invalid row key");
-        }
-        return *row;
-    }
-
-    template<typename RowKeyType>
-    AttributeRow *AttributeTable<RowKeyType>::getRowPtr(const RowKeyType &key)
-    {
-        auto iter = m_rows.find(key);
-        if (iter == m_rows.end())
-        {
-            return 0;
-        }
-        return iter->second.get();
-    }
-
-    template<typename RowKeyType>
-    const AttributeRow *AttributeTable<RowKeyType>::getRowPtr(const RowKeyType &key) const
-    {
-        auto iter = m_rows.find(key);
-        if (iter == m_rows.end())
-        {
-            return 0;
-        }
-        return iter->second.get();
-    }
-
-    template<class RowKeyType>
-    AttributeRow &AttributeTable<RowKeyType>::addRow(const RowKeyType &key)
-    {
-        auto iter = m_rows.find(key);
-        if (iter != m_rows.end())
-        {
-            throw new std::invalid_argument("Duplicate key");
-        }
-        auto res = m_rows.insert(std::make_pair(key, std::unique_ptr<AttributeRowImpl>(new AttributeRowImpl(*this))));
-        return *res.first->second;
-    }
-
-    template<typename RowKeyType>
-    AttributeColumn &AttributeTable<RowKeyType>::getColumn(size_t index)
-    {
-        checkColumnIndex(index);
-        return m_columns[index];
-    }
-
-    template<class RowKeyType>
-    size_t AttributeTable<RowKeyType>::insertOrResetColumn(const std::string &columnName, const std::string &formula)
-    {
-        auto iter = m_columnMapping.find(columnName);
-        if (iter == m_columnMapping.end())
-        {
-            return addColumnInternal(columnName, formula);
-        }
-
-        // it exists - we need to reset it
-        m_columns[iter->second].m_stats = AttributeColumnStats();
-        m_columns[iter->second].setLock(false);
-        for (auto& row : m_rows)
-        {
-            row.second->setValue(iter->second, -1.0f);
-        }
-        return iter->second;
-    }
-
-    template<class RowKeyType>
-    size_t AttributeTable<RowKeyType>::insertOrResetLockedColumn(const std::string &columnName, const std::string &formula)
-    {
-        size_t index = insertOrResetColumn(columnName, formula);
-        m_columns[index].setLock(true);
-        return index;
-    }
-
-    template<class RowKeyType>
-    size_t AttributeTable<RowKeyType>::getOrInsertColumn(const std::string &columnName, const std::string &formula)
-    {
-        auto iter = m_columnMapping.find(columnName);
-        if ( iter != m_columnMapping.end())
-        {
-            return iter->second;
-        }
-        return addColumnInternal(columnName, formula);
-    }
-
-    template<class RowKeyType>
-    size_t AttributeTable<RowKeyType>::getOrInsertLockedColumn(const std::string &columnName, const std::string &formula)
-    {
-        size_t index = getOrInsertColumn(columnName, formula);
-        m_columns[index].setLock(true);
-        return index;
-    }
-
-    template<class RowKeyType>
-    void AttributeTable<RowKeyType>::removeColumn(size_t colIndex)
-    {
-        checkColumnIndex(colIndex);
-        const std::string& name = m_columns[colIndex].getName();
-        auto iter = m_columnMapping.find(name);
-        m_columnMapping.erase(iter);
-        for (auto& elem : m_columnMapping)
-        {
-            if (elem.second > colIndex)
-            {
-                elem.second--;
-            }
-        }
-        m_columns.erase(m_columns.begin()+colIndex);
-        for (auto& row : m_rows)
-        {
-            row.second->removeColumn(colIndex);
-        }
-    }
-
-    template<class RowKeyType>
-    void AttributeTable<RowKeyType>::renameColumn(const std::string &oldName, const std::string &newName)
-    {
-        auto iter = m_columnMapping.find(oldName);
-        if (iter == m_columnMapping.end())
-        {
-            throw std::out_of_range("Invalid column name");
-        }
-
-        size_t colIndex = iter->second;
-        m_columns[colIndex].setName(newName);
-        m_columnMapping.erase(iter);
-        m_columnMapping[newName] = colIndex;
-
-    }
-
-    template<typename RowKeyType>
-    void AttributeTable<RowKeyType>::deselectAllRows()
-    {
-        for (auto& row : m_rows)
-        {
-            row.second->setSelection(false);
-        }
-    }
-
-    template<typename RowKeyType>
-    void AttributeTable<RowKeyType>::setDisplayParamsForAllAttributes(const DisplayParams &params)
-    {
-        for (auto& col: m_columns)
-        {
-            col.setDisplayParams(params);
-        }
-
-    }
-
-    template<typename RowKeyType>
-    void AttributeTable<RowKeyType>::read(std::istream &stream, LayerManager &layerManager, int version)
-    {
-        layerManager.read(stream);
-        int colcount;
-        stream.read((char *)&colcount, sizeof(colcount));
-        std::map<size_t, AttributeColumnImpl> tmp;
-        for (int j = 0; j < colcount; j++) {
-            AttributeColumnImpl col("");
-            tmp[col.read(stream, METAGRAPH_VERSION)] = col;
-        }
-        for (auto & c : tmp)
-        {
-            m_columnMapping[c.second.getName()] = m_columns.size();
-            m_columns.push_back(c.second);
-        }
-
-        int rowcount, rowkey;
-        stream.read((char *)&rowcount, sizeof(rowcount));
-        for (int i = 0; i < rowcount; i++) {
-           stream.read((char *)&rowkey, sizeof(rowkey));
-           auto row = std::unique_ptr<AttributeRowImpl>(new AttributeRowImpl(*this));
-           row->read(stream, METAGRAPH_VERSION);
-           m_rows.insert(std::make_pair(rowkey,std::move(row)));
-        }
-
-       // ref column display params
-       stream.read((char *)&m_displayParams,sizeof(DisplayParams));
-    }
-
-    template<typename RowKeyType>
-    void AttributeTable<RowKeyType>::write(std::ostream &stream, const LayerManager &layerManager)
-    {
-        layerManager.write(stream);
-        int colCount = (int)m_columns.size();
-        stream.write((char *)&colCount, sizeof(int));
-        for (size_t i = 0; i < m_columns.size(); ++i)
-        {
-            m_columns[i].write(stream, (int)i);
-        }
-
-        int rowcount = (int)m_rows.size();
-        stream.write((char *)&rowcount, sizeof(int));
-        for ( auto &kvp : m_rows)
-        {
-            kvp.first.write(stream);
-            kvp.second->write(stream);
-        }
-        stream.write((const char *)&m_displayParams, sizeof(DisplayParams));
-    }
-
-    template<class RowKeyType>
-    size_t AttributeTable<RowKeyType>::getColumnIndex(const std::string &name) const
-    {
-        auto iter = m_columnMapping.find(name);
-        if (iter == m_columnMapping.end())
-        {
-            std::stringstream message;
-            message << "Unknown column name " << name;
-            throw std::out_of_range(message.str());
-        }
-        return iter->second;
-
-    }
-
-    template<class RowKeyType>
-    const AttributeColumn &AttributeTable<RowKeyType>::getColumn(size_t index) const
-    {
-        checkColumnIndex(index);
-        return m_columns[index];
-    }
-
-    template<class RowKeyType>
-    const std::string &AttributeTable<RowKeyType>::getColumnName(size_t index) const
-    {
-        checkColumnIndex(index);
-        return m_columns[index].getName();
-    }
-
-    template<class RowKeyType>
-    size_t AttributeTable<RowKeyType>::getNumColumns() const
-    {
-        return m_columns.size();
-    }
-
-    template<class RowKeyType>
-    void AttributeTable<RowKeyType>::checkColumnIndex(size_t index) const
-    {
-        if (index >= m_columns.size())
-        {
-            throw std::out_of_range("ColumnIndex out of range");
-        }
-    }
-
-    template<class RowKeyType>
-    size_t AttributeTable<RowKeyType>::addColumnInternal(const std::string &name, const std::string &formula)
-    {
-        size_t colIndex = m_columns.size();
-        m_columns.push_back(AttributeColumnImpl(name, formula));
-        m_columnMapping[name] = colIndex;
-        for (auto& elem : m_rows)
-        {
-            elem.second->addColumn();
-        }
-        return colIndex;
-    }
 }
 

--- a/salalib/attributetable.h
+++ b/salalib/attributetable.h
@@ -403,8 +403,9 @@ namespace dXreimpl
         public:
             iterator(const typename StorageType::iterator& iter) : const_iterator_impl<typename StorageType::iterator>(iter)
             {}
-            template<typename other_type> iterator(const const_iterator_impl<other_type>& other) : const_iterator_impl<typename StorageType::iterator>::m_item(other.m_item)
-            {}
+            template<typename other_type> iterator(const const_iterator_impl<other_type>& other) : const_iterator_impl<StorageType::iterator>(other.item){
+               // m_item = other.m_item;
+            }
             template<typename other_type> iterator& operator =(const const_iterator_impl<other_type> &other)
             {
                 const_iterator_impl<typename StorageType::iterator>::m_item = other.m_item;

--- a/salalib/attributetablehelpers.h
+++ b/salalib/attributetablehelpers.h
@@ -20,8 +20,7 @@
 #include "mgraph_consts.h"
 
 namespace dXreimpl{
-    template<typename RowKeyType>
-    inline void pushSelectionToLayer(AttributeTable<RowKeyType> &table, LayerManager& layerManager, const std::string &layerName)
+    inline void pushSelectionToLayer(AttributeTable &table, LayerManager& layerManager, const std::string &layerName)
     {
         size_t layerIndex = layerManager.addLayer(layerName);
         LayerManager::KeyType layerKey = layerManager.getKey(layerIndex);
@@ -37,7 +36,7 @@ namespace dXreimpl{
         layerManager.setLayerVisible(layerIndex);
     }
 
-    inline PafColor getDisplayColor( const SerialisedPixelRef& key, const AttributeRow& row, const AttributeTableView& tableView, bool checkSelectionStatus = false)
+    inline PafColor getDisplayColor( const AttributeKey& key, const AttributeRow& row, const AttributeTableView& tableView, bool checkSelectionStatus = false)
     {
         if ( checkSelectionStatus && row.isSelected())
         {

--- a/salalib/attributetableindex.cpp
+++ b/salalib/attributetableindex.cpp
@@ -1,0 +1,106 @@
+// Copyright (C) 2018 Christian Sailer
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#include "salalib/attributetableindex.h"
+
+namespace dXreimpl {
+    std::vector<ConstAttributeIndexItem> makeAttributeIndex(const AttributeTable &table, int colIndex)
+    {
+        std::vector<ConstAttributeIndexItem> index;
+        size_t numRows = table.getNumRows();
+        if (numRows == 0)
+        {
+            return index;
+        }
+        index.reserve(numRows);
+        // perturb the values to be sorted by so same values will be in order of appearence in the map
+        size_t idx = 0;
+        if ( colIndex == -1 )
+        {
+            double perturbationFactor = 1e-9 / numRows;
+            for (auto& item: table)
+            {
+                double value = (double)item.getKey().value;
+                value += idx * perturbationFactor;
+
+                index.push_back(ConstAttributeIndexItem(item.getKey(), value, item.getRow()));
+                ++idx;
+            }
+        }
+        else if (colIndex >= 0 )
+        {
+            double perturbationFactor = table.getColumn(colIndex).getStats().max * 1e-9 / numRows;
+            for (auto & item : table)
+            {
+                double value = item.getRow().getValue(colIndex);
+                value += idx * perturbationFactor;
+
+                index.push_back(ConstAttributeIndexItem(item.getKey(), value, item.getRow()));
+                ++idx;
+            }
+        }
+        else
+        {
+            throw std::out_of_range("Column index out of range");
+        }
+        std::sort(index.begin(), index.end());
+        return index;
+    }
+
+    std::vector<AttributeIndexItem> makeAttributeIndex(AttributeTable &table, int colIndex)
+    {
+        std::vector<AttributeIndexItem> index;
+        size_t numRows = table.getNumRows();
+        if (numRows == 0)
+        {
+            return index;
+        }
+        index.reserve(numRows);
+        // perturb the values to be sorted by so same values will be in order of appearence in the map
+        size_t idx = 0;
+        if ( colIndex == -1 )
+        {
+            double perturbationFactor = 1e-9 / numRows;
+            for (auto& item: table)
+            {
+                double value = (double)item.getKey().value;
+                value += idx * perturbationFactor;
+
+                index.push_back(AttributeIndexItem(item.getKey(), value, item.getRow()));
+                ++idx;
+            }
+        }
+        else if (colIndex >= 0 )
+        {
+            double perturbationFactor = table.getColumn(colIndex).getStats().max * 1e-9 / numRows;
+            for (auto & item : table)
+            {
+                double value = item.getRow().getValue(colIndex);
+                value += idx * perturbationFactor;
+
+                index.push_back(AttributeIndexItem(item.getKey(), value, item.getRow()));
+                ++idx;
+            }
+        }
+        else
+        {
+            throw std::out_of_range("Column index out of range");
+        }
+        std::sort(index.begin(), index.end());
+        return index;
+    }
+
+}

--- a/salalib/attributetableindex.h
+++ b/salalib/attributetableindex.h
@@ -19,11 +19,10 @@
 
 namespace dXreimpl
 {
-    template<typename RowKeyType>
     class ConstAttributeIndexItem
     {
     public:
-        ConstAttributeIndexItem(const RowKeyType &k, double v, const AttributeRow &r) : key(k), value(v), row(&r)
+        ConstAttributeIndexItem(const AttributeKey &k, double v, const AttributeRow &r) : key(k), value(v), row(&r)
         {}
 
         ConstAttributeIndexItem(const ConstAttributeIndexItem& other) : key(other.key), value(other.value), row(other.row)
@@ -40,18 +39,17 @@ namespace dXreimpl
             return *this;
         }
 
-        RowKeyType key;
+        AttributeKey key;
         double value;
         const AttributeRow *  row;
     };
 
-    template<typename RowKeyType>
-    class AttributeIndexItem : public ConstAttributeIndexItem<RowKeyType>
+    class AttributeIndexItem : public ConstAttributeIndexItem
     {
     public:
-        AttributeIndexItem( const RowKeyType &k, double v, AttributeRow &r) : ConstAttributeIndexItem<RowKeyType>(k,v,r), mutable_row(&r)
+        AttributeIndexItem( const AttributeKey &k, double v, AttributeRow &r) : ConstAttributeIndexItem(k,v,r), mutable_row(&r)
         {}
-        AttributeIndexItem( const AttributeIndexItem &other) : ConstAttributeIndexItem<RowKeyType>(other), mutable_row(other.mutable_row)
+        AttributeIndexItem( const AttributeIndexItem &other) : ConstAttributeIndexItem(other), mutable_row(other.mutable_row)
         {}
         AttributeIndexItem &operator = (const AttributeIndexItem &other)
         {
@@ -59,7 +57,7 @@ namespace dXreimpl
             {
                 return *this;
             }
-            ConstAttributeIndexItem<RowKeyType>::operator =(other);
+            ConstAttributeIndexItem::operator =(other);
             mutable_row = other.mutable_row;
             return *this;
         }
@@ -67,53 +65,11 @@ namespace dXreimpl
         AttributeRow *mutable_row;
     };
 
-    template<typename T1>
-    bool operator < (const ConstAttributeIndexItem<T1> &lhs, const ConstAttributeIndexItem<T1> &rhs)
+    inline bool operator < (const ConstAttributeIndexItem &lhs, const ConstAttributeIndexItem &rhs)
     {
         return lhs.value < rhs.value;
     }
 
-    template<typename ItemType, typename TableType>
-    std::vector<ItemType> makeAttributeIndex(TableType &table, int colIndex)
-    {
-        std::vector<ItemType> index;
-        size_t numRows = table.getNumRows();
-        if (numRows == 0)
-        {
-            return index;
-        }
-        index.reserve(numRows);
-        // perturb the values to be sorted by so same values will be in order of appearence in the map
-        size_t idx = 0;
-        if ( colIndex == -1 )
-        {
-            double perturbationFactor = 1e-9 / numRows;
-            for (auto& item: table)
-            {
-                double value = (double)item.getKey().value;
-                value += idx * perturbationFactor;
-
-                index.push_back(ItemType(item.getKey(), value, item.getRow()));
-                ++idx;
-            }
-        }
-        else if (colIndex >= 0 )
-        {
-            double perturbationFactor = table.getColumn(colIndex).getStats().max * 1e-9 / numRows;
-            for (auto & item : table)
-            {
-                double value = item.getRow().getValue(colIndex);
-                value += idx * perturbationFactor;
-
-                index.push_back(ItemType(item.getKey(), value, item.getRow()));
-                ++idx;
-            }
-        }
-        else
-        {
-            throw std::out_of_range("Column index out of range");
-        }
-        std::sort(index.begin(), index.end());
-        return index;
-    }
+    std::vector<ConstAttributeIndexItem> makeAttributeIndex(const AttributeTable &table, int colIndex);
+    std::vector<AttributeIndexItem> makeAttributeIndex(AttributeTable &table, int colIndex);
 }

--- a/salalib/attributetableview.cpp
+++ b/salalib/attributetableview.cpp
@@ -15,7 +15,7 @@
 
 #include "attributetableview.h"
 
-AttributeTableView::AttributeTableView(const dXreimpl::AttributeTable<dXreimpl::SerialisedPixelRef> &table) : m_table(table), m_displayColumn(-1)
+AttributeTableView::AttributeTableView(const dXreimpl::AttributeTable &table) : m_table(table), m_displayColumn(-1)
 {}
 
 void AttributeTableView::setDisplayColIndex(int columnIndex){
@@ -26,11 +26,11 @@ void AttributeTableView::setDisplayColIndex(int columnIndex){
         return;
     }
     // recalculate the index even if it's the same column in case stuff has changed
-    m_index = dXreimpl::makeAttributeIndex<dXreimpl::ConstAttributeIndexItem<dXreimpl::SerialisedPixelRef>>(m_table, columnIndex);
+    m_index = dXreimpl::makeAttributeIndex(m_table, columnIndex);
     m_displayColumn = columnIndex;
 }
 
-float AttributeTableView::getNormalisedValue(const dXreimpl::SerialisedPixelRef &key, const dXreimpl::AttributeRow &row) const
+float AttributeTableView::getNormalisedValue(const dXreimpl::AttributeKey &key, const dXreimpl::AttributeRow &row) const
 {
     if ( m_displayColumn < 0)
     {
@@ -58,7 +58,7 @@ void AttributeTableHandle::setDisplayColIndex(int columnIndex){
     else
     {
         // recalculate the index even if it's the same column in case stuff has changed
-        m_mutableIndex = dXreimpl::makeAttributeIndex<dXreimpl::AttributeIndexItem<dXreimpl::SerialisedPixelRef>>(m_mutableTable, columnIndex);
+        m_mutableIndex = dXreimpl::makeAttributeIndex(m_mutableTable, columnIndex);
     }
     AttributeTableView::setDisplayColIndex(columnIndex);
 }

--- a/salalib/attributetableview.h
+++ b/salalib/attributetableview.h
@@ -21,18 +21,18 @@
 class AttributeTableView
 {
 public:
-    AttributeTableView(const dXreimpl::AttributeTable<dXreimpl::SerialisedPixelRef>& table );
+    AttributeTableView(const dXreimpl::AttributeTable& table );
 
-    const dXreimpl::AttributeTable<dXreimpl::SerialisedPixelRef> &m_table;
+    const dXreimpl::AttributeTable &m_table;
 
     // columnIndex < 0 -> not set
     virtual void setDisplayColIndex(int columnIndex);
     int getDisplayColIndex() const{ return m_displayColumn;}
 
-    float getNormalisedValue(const dXreimpl::SerialisedPixelRef& key, const dXreimpl::AttributeRow &row) const;
+    float getNormalisedValue(const dXreimpl::AttributeKey& key, const dXreimpl::AttributeRow &row) const;
     const DisplayParams& getDisplayParams() const;
 
-    typedef std::vector<dXreimpl::ConstAttributeIndexItem<dXreimpl::SerialisedPixelRef>> ConstIndex;
+    typedef std::vector<dXreimpl::ConstAttributeIndexItem> ConstIndex;
     const ConstIndex& getConstTableIndex() const{return m_index;}
 
     const dXreimpl::AttributeColumn& getDisplayedColumn() const;
@@ -45,12 +45,12 @@ private:
 class AttributeTableHandle : public AttributeTableView
 {
 public:
-    AttributeTableHandle(dXreimpl::AttributeTable<dXreimpl::SerialisedPixelRef> &table) : m_mutableTable(table), AttributeTableView(table){}
-    typedef std::vector<dXreimpl::AttributeIndexItem<dXreimpl::SerialisedPixelRef>> Index;
+    AttributeTableHandle(dXreimpl::AttributeTable &table) : m_mutableTable(table), AttributeTableView(table){}
+    typedef std::vector<dXreimpl::AttributeIndexItem> Index;
     const Index& getTableIndex() const {return m_mutableIndex;}
     virtual void setDisplayColIndex(int columnIndex);
 private:
-    dXreimpl::AttributeTable<dXreimpl::SerialisedPixelRef>& m_mutableTable;
+    dXreimpl::AttributeTable& m_mutableTable;
     Index m_mutableIndex;
 
 };

--- a/salalib/pointdata.h
+++ b/salalib/pointdata.h
@@ -22,6 +22,7 @@
 #include "genlib/exceptions.h"
 #include "salalib/point.h"
 #include "salalib/options.h"
+#include "salalib/attributetable.h"
 #include <vector>
 #include <set>
 #include <deque>

--- a/salalib/salalib.pro
+++ b/salalib/salalib.pro
@@ -47,7 +47,8 @@ SOURCES += \
     axialpolygons.cpp \
     tidylines.cpp \
     mapconverter.cpp \
-    importutils.cpp
+    importutils.cpp \
+    attributetableindex.cpp
 
 HEADERS += \
     attributes.h \


### PR DESCRIPTION
The original version of the new attribute map had the attribute key as a template argument. However, this seems to be a needless complication - all attribute tables in depthmap must have the same, int based key as e.g. the attributemap from an axial map (index based key) and a point map (pixel based key) are assumed to be compatible in the higher layers of the code base.