### PR TITLE
Fix sala script

### DIFF
--- a/salaTest/testsalaprogram.cpp
+++ b/salaTest/testsalaprogram.cpp
@@ -122,10 +122,7 @@ TEST_CASE("Trivial errors") {
 
 }
 
-TEST_CASE("Trivial scripts with unexpected results") {
-    // These are cases where the result is not as expected i.e. for
-    // a pythonesque language
-
+TEST_CASE("Variables from outer scope are accessible in inner scope") {
     std::stringstream script;
     SalaObj expected;
     SECTION("No access to globabl scope from within a for loop") {
@@ -133,7 +130,7 @@ TEST_CASE("Trivial scripts with unexpected results") {
                << "for i in range(0,1):\n"
                << "    x = 100\n"
                << "x";
-        expected = SalaObj(5);
+        expected = SalaObj(100);
     }
 
     SalaGrf graph;
@@ -141,7 +138,7 @@ TEST_CASE("Trivial scripts with unexpected results") {
     SalaProgram program(context);
     program.parse(script);
     SalaObj result = program.evaluate();
-    REQUIRE(result == expected);
+    REQUIRE(result.toInt() == expected.toInt());
 }
 
 TEST_CASE("Shapemap scripts") {
@@ -285,76 +282,76 @@ TEST_CASE("Shapemap scripts with unexpected results") {
             expectedColVals.push_back(0.0);
             expectedColVals.push_back(0.0);
             expectedColVals.push_back(0.0);
-            expectedColVals.push_back(-1.0);
-            expectedColVals.push_back(-1.0);
+            expectedColVals.push_back(2.0);
+            expectedColVals.push_back(5.0);
     }
 
-    SECTION("Total Depth Calculation") {
-            script << "total_depth = 0\n"
-                   << "depth = 0\n"
-                   << "pop_list = [this]\n"
-                   << "push_list = []\n"
-                   << "setmark(true)\n"
-                   << "while len(pop_list):\n"
-                   << "    total_depth = total_depth + depth\n"
-                   << "    curs = pop_list.pop()\n"
-                   << "    for i in curs.connections():\n"
-                   << "        if i.mark() is none:\n"
-                   << "            i.setmark(true)\n"
-                   << "            push_list.append(i)\n"
-                   << "    if len(pop_list) == 0:\n"
-                   << "        depth = depth + 1\n"
-                   << "        pop_list = push_list\n"
-                   << "        push_list = []\n"
-                   << "total_depth\n";
-            expectedColVals.push_back(-1.0);
-            expectedColVals.push_back(-1.0);
-            expectedColVals.push_back(-1.0);
-            expectedColVals.push_back(-1.0);
-            expectedColVals.push_back(-1.0);
-    }
+//    SECTION("Total Depth Calculation") {
+//            script << "total_depth = 0\n"
+//                   << "depth = 0\n"
+//                   << "pop_list = [this]\n"
+//                   << "push_list = []\n"
+//                   << "setmark(true)\n"
+//                   << "while len(pop_list):\n"
+//                   << "    total_depth = total_depth + depth\n"
+//                   << "    curs = pop_list.pop()\n"
+//                   << "    for i in curs.connections():\n"
+//                   << "        if i.mark() is none:\n"
+//                   << "            i.setmark(true)\n"
+//                   << "            push_list.append(i)\n"
+//                   << "    if len(pop_list) == 0:\n"
+//                   << "        depth = depth + 1\n"
+//                   << "        pop_list = push_list\n"
+//                   << "        push_list = []\n"
+//                   << "total_depth\n";
+//            expectedColVals.push_back(-1.0);
+//            expectedColVals.push_back(-1.0);
+//            expectedColVals.push_back(-1.0);
+//            expectedColVals.push_back(-1.0);
+//            expectedColVals.push_back(-1.0);
+//    }
 
-    SECTION("Shortest Cycle") {
-            script << "push_list = []\n"
-                   << "pop_list = []\n"
-                   << "live_paths = []\n"
-                   << "setmark([-1,0])\n"
-                   << "depth = 1\n"
-                   << "path_index = 0\n"
-                   << "for i in connections():\n"
-                   << "    pop_list.append([path_index,i])\n"
-                   << "    live_paths.append(1)\n"
-                   << "    i.setmark([path_index,depth])\n"
-                   << "    path_index = path_index + 1\n"
-                   << "if path_index < 2:\n"
-                   << "    return -1 # no cycle possible\n"
-                   << "live_path_count = path_index\n"
-                   << "while len(pop_list) and live_path_count > 1:\n"
-                   << "    curs = pop_list.pop()\n"
-                   << "    path_index = curs[0]\n"
-                   << "    this_node = curs[1]\n"
-                   << "    live_paths[path_index] = live_paths[path_index] - 1\n"
-                   << "    for i in this_node.connections():\n"
-                   << "        if i.mark() is none:\n"
-                   << "            i.setmark([path_index,depth+1])\n"
-                   << "            push_list.append([path_index,i])\n"
-                   << "            live_paths[path_index] = live_paths[path_index] + 1\n"
-                   << "        elif i.mark()[0] != path_index and i.mark()[0] != -1:\n"
-                   << "            # found a cycle!\n"
-                   << "            return i.mark()[1] + this_node.mark()[1] + 1\n"
-                   << "    if live_paths[path_index] == 0:\n"
-                   << "        live_path_count = live_path_count - 1\n"
-                   << "    if len(pop_list) == 0:\n"
-                   << "        depth = depth + 1\n"
-                   << "        pop_list = push_list\n"
-                   << "        push_list = []\n"
-                   << "-1 # no cycle found\n";
-            expectedColVals.push_back(-1.0);
-            expectedColVals.push_back(-1.0);
-            expectedColVals.push_back(-1.0);
-            expectedColVals.push_back(-1.0);
-            expectedColVals.push_back(-1.0);
-    }
+//    SECTION("Shortest Cycle") {
+//            script << "push_list = []\n"
+//                   << "pop_list = []\n"
+//                   << "live_paths = []\n"
+//                   << "setmark([-1,0])\n"
+//                   << "depth = 1\n"
+//                   << "path_index = 0\n"
+//                   << "for i in connections():\n"
+//                   << "    pop_list.append([path_index,i])\n"
+//                   << "    live_paths.append(1)\n"
+//                   << "    i.setmark([path_index,depth])\n"
+//                   << "    path_index = path_index + 1\n"
+//                   << "if path_index < 2:\n"
+//                   << "    return -1 # no cycle possible\n"
+//                   << "live_path_count = path_index\n"
+//                   << "while len(pop_list) and live_path_count > 1:\n"
+//                   << "    curs = pop_list.pop()\n"
+//                   << "    path_index = curs[0]\n"
+//                   << "    this_node = curs[1]\n"
+//                   << "    live_paths[path_index] = live_paths[path_index] - 1\n"
+//                   << "    for i in this_node.connections():\n"
+//                   << "        if i.mark() is none:\n"
+//                   << "            i.setmark([path_index,depth+1])\n"
+//                   << "            push_list.append([path_index,i])\n"
+//                   << "            live_paths[path_index] = live_paths[path_index] + 1\n"
+//                   << "        elif i.mark()[0] != path_index and i.mark()[0] != -1:\n"
+//                   << "            # found a cycle!\n"
+//                   << "            return i.mark()[1] + this_node.mark()[1] + 1\n"
+//                   << "    if live_paths[path_index] == 0:\n"
+//                   << "        live_path_count = live_path_count - 1\n"
+//                   << "    if len(pop_list) == 0:\n"
+//                   << "        depth = depth + 1\n"
+//                   << "        pop_list = push_list\n"
+//                   << "        push_list = []\n"
+//                   << "-1 # no cycle found\n";
+//            expectedColVals.push_back(-1.0);
+//            expectedColVals.push_back(-1.0);
+//            expectedColVals.push_back(-1.0);
+//            expectedColVals.push_back(-1.0);
+//            expectedColVals.push_back(-1.0);
+//    }
 
 
 

--- a/salaTest/testsalaprogram.cpp
+++ b/salaTest/testsalaprogram.cpp
@@ -286,72 +286,72 @@ TEST_CASE("Shapemap scripts with unexpected results") {
             expectedColVals.push_back(5.0);
     }
 
-//    SECTION("Total Depth Calculation") {
-//            script << "total_depth = 0\n"
-//                   << "depth = 0\n"
-//                   << "pop_list = [this]\n"
-//                   << "push_list = []\n"
-//                   << "setmark(true)\n"
-//                   << "while len(pop_list):\n"
-//                   << "    total_depth = total_depth + depth\n"
-//                   << "    curs = pop_list.pop()\n"
-//                   << "    for i in curs.connections():\n"
-//                   << "        if i.mark() is none:\n"
-//                   << "            i.setmark(true)\n"
-//                   << "            push_list.append(i)\n"
-//                   << "    if len(pop_list) == 0:\n"
-//                   << "        depth = depth + 1\n"
-//                   << "        pop_list = push_list\n"
-//                   << "        push_list = []\n"
-//                   << "total_depth\n";
-//            expectedColVals.push_back(-1.0);
-//            expectedColVals.push_back(-1.0);
-//            expectedColVals.push_back(-1.0);
-//            expectedColVals.push_back(-1.0);
-//            expectedColVals.push_back(-1.0);
-//    }
+    SECTION("Total Depth Calculation") {
+            script << "total_depth = 0\n"
+                   << "depth = 0\n"
+                   << "pop_list = [this]\n"
+                   << "push_list = []\n"
+                   << "setmark(true)\n"
+                   << "while len(pop_list):\n"
+                   << "    total_depth = total_depth + depth\n"
+                   << "    curs = pop_list.pop()\n"
+                   << "    for i in curs.connections():\n"
+                   << "        if i.mark() is none:\n"
+                   << "            i.setmark(true)\n"
+                   << "            push_list.append(i)\n"
+                   << "    if len(pop_list) == 0:\n"
+                   << "        depth = depth + 1\n"
+                   << "        pop_list = push_list\n"
+                   << "        push_list = []\n"
+                   << "total_depth\n";
+            expectedColVals.push_back(7.0);
+            expectedColVals.push_back(10.0);
+            expectedColVals.push_back(6.0);
+            expectedColVals.push_back(7.0);
+            expectedColVals.push_back(10.0);
+    }
 
-//    SECTION("Shortest Cycle") {
-//            script << "push_list = []\n"
-//                   << "pop_list = []\n"
-//                   << "live_paths = []\n"
-//                   << "setmark([-1,0])\n"
-//                   << "depth = 1\n"
-//                   << "path_index = 0\n"
-//                   << "for i in connections():\n"
-//                   << "    pop_list.append([path_index,i])\n"
-//                   << "    live_paths.append(1)\n"
-//                   << "    i.setmark([path_index,depth])\n"
-//                   << "    path_index = path_index + 1\n"
-//                   << "if path_index < 2:\n"
-//                   << "    return -1 # no cycle possible\n"
-//                   << "live_path_count = path_index\n"
-//                   << "while len(pop_list) and live_path_count > 1:\n"
-//                   << "    curs = pop_list.pop()\n"
-//                   << "    path_index = curs[0]\n"
-//                   << "    this_node = curs[1]\n"
-//                   << "    live_paths[path_index] = live_paths[path_index] - 1\n"
-//                   << "    for i in this_node.connections():\n"
-//                   << "        if i.mark() is none:\n"
-//                   << "            i.setmark([path_index,depth+1])\n"
-//                   << "            push_list.append([path_index,i])\n"
-//                   << "            live_paths[path_index] = live_paths[path_index] + 1\n"
-//                   << "        elif i.mark()[0] != path_index and i.mark()[0] != -1:\n"
-//                   << "            # found a cycle!\n"
-//                   << "            return i.mark()[1] + this_node.mark()[1] + 1\n"
-//                   << "    if live_paths[path_index] == 0:\n"
-//                   << "        live_path_count = live_path_count - 1\n"
-//                   << "    if len(pop_list) == 0:\n"
-//                   << "        depth = depth + 1\n"
-//                   << "        pop_list = push_list\n"
-//                   << "        push_list = []\n"
-//                   << "-1 # no cycle found\n";
-//            expectedColVals.push_back(-1.0);
-//            expectedColVals.push_back(-1.0);
-//            expectedColVals.push_back(-1.0);
-//            expectedColVals.push_back(-1.0);
-//            expectedColVals.push_back(-1.0);
-//    }
+    SECTION("Shortest Cycle") {
+            script << "push_list = []\n"
+                   << "pop_list = []\n"
+                   << "live_paths = []\n"
+                   << "setmark([-1,0])\n"
+                   << "depth = 1\n"
+                   << "path_index = 0\n"
+                   << "for i in connections():\n"
+                   << "    pop_list.append([path_index,i])\n"
+                   << "    live_paths.append(1)\n"
+                   << "    i.setmark([path_index,depth])\n"
+                   << "    path_index = path_index + 1\n"
+                   << "if path_index < 2:\n"
+                   << "    return -1 # no cycle possible\n"
+                   << "live_path_count = path_index\n"
+                   << "while len(pop_list) and live_path_count > 1:\n"
+                   << "    curs = pop_list.pop()\n"
+                   << "    path_index = curs[0]\n"
+                   << "    this_node = curs[1]\n"
+                   << "    live_paths[path_index] = live_paths[path_index] - 1\n"
+                   << "    for i in this_node.connections():\n"
+                   << "        if i.mark() is none:\n"
+                   << "            i.setmark([path_index,depth+1])\n"
+                   << "            push_list.append([path_index,i])\n"
+                   << "            live_paths[path_index] = live_paths[path_index] + 1\n"
+                   << "        elif i.mark()[0] != path_index and i.mark()[0] != -1:\n"
+                   << "            # found a cycle!\n"
+                   << "            return i.mark()[1] + this_node.mark()[1] + 1\n"
+                   << "    if live_paths[path_index] == 0:\n"
+                   << "        live_path_count = live_path_count - 1\n"
+                   << "    if len(pop_list) == 0:\n"
+                   << "        depth = depth + 1\n"
+                   << "        pop_list = push_list\n"
+                   << "        push_list = []\n"
+                   << "-1 # no cycle found\n";
+            expectedColVals.push_back(-1.0);
+            expectedColVals.push_back(-1.0);
+            expectedColVals.push_back(-1.0);
+            expectedColVals.push_back(-1.0);
+            expectedColVals.push_back(-1.0);
+    }
 
 
 

--- a/salaTest/testsalaprogram.cpp
+++ b/salaTest/testsalaprogram.cpp
@@ -125,7 +125,7 @@ TEST_CASE("Trivial errors") {
 TEST_CASE("Variables from outer scope are accessible in inner scope") {
     std::stringstream script;
     SalaObj expected;
-    SECTION("No access to globabl scope from within a for loop") {
+    SECTION("Access to global scope from within a for loop") {
         script << "x = 5\n"
                << "for i in range(0,1):\n"
                << "    x = 100\n"

--- a/salalib/salaprogram.cpp
+++ b/salalib/salaprogram.cpp
@@ -885,12 +885,14 @@ int SalaCommand::decode(std::string string)   // string copied as makelower appl
             SalaCommand *parent = m_parent;
             auto n = parent->m_var_names.end();
             int x = -1;
-            while (parent != NULL && n == parent->m_var_names.end()) {
+            while (parent != NULL) {
                n = parent->m_var_names.find(string);
                if (n != parent->m_var_names.end()) {
                   x = n->second;
+                  parent = NULL;
+               } else {
+                  parent = parent->m_parent;
                }
-               parent = parent->m_parent;
             }
             if (x != -1) {
                m_eval_stack.push_back( SalaObj( SalaObj::S_VAR, x) );

--- a/salalib/salaprogram.cpp
+++ b/salalib/salaprogram.cpp
@@ -261,10 +261,7 @@ SalaObj SalaProgram::evaluate()
 
    // clear marks if they've been used:
    if (m_marked) {
-      AttributeTable *table = m_thisobj.getTable();
-      for (int i = 0; i < table->getRowCount(); i++) {
-          m_thisobj.marks[i] = SalaObj();
-      }
+      marks.clear();
       m_marked = false;
    }
 
@@ -1566,13 +1563,13 @@ SalaObj SalaCommand::evaluate(int& pointer, SalaObj* &p_obj)
                   {
                      param.ensureNone();
                      AttributeTable *table = obj.getTable();
-                     data = obj.marks[(obj.type == SalaObj::S_POINTMAPOBJ) ? table->getRowid(obj.data.graph.node) : obj.data.graph.node];
+                     data = m_program->marks[(obj.type == SalaObj::S_POINTMAPOBJ) ? table->getRowid(obj.data.graph.node) : obj.data.graph.node];
                   }
                   break;
                case SalaObj::S_FSETMARK:
                   {
                      AttributeTable *table = obj.getTable();
-                     obj.marks[(obj.type == SalaObj::S_POINTMAPOBJ) ? table->getRowid(obj.data.graph.node) : obj.data.graph.node] = param;
+                     m_program->marks[(obj.type == SalaObj::S_POINTMAPOBJ) ? table->getRowid(obj.data.graph.node) : obj.data.graph.node] = param;
                      m_program->m_marked = true;   // <- this tells the program to tidy up marks between executions
                      data = SalaObj(); // returns none
                   }

--- a/salalib/salaprogram.h
+++ b/salalib/salaprogram.h
@@ -246,7 +246,6 @@ public:
    //
    // operations for graphs / graph nodes:
    AttributeTable *getTable();
-   std::map<int, SalaObj> marks;
    //
    const std::string getTypeStr() const;
    const std::string getTypeIndefArt() const;
@@ -308,6 +307,9 @@ class SalaProgram
    SalaObj m_thisobj;
    //
    bool m_marked; // this is used to tell the program that a node has been "marked" -- all marks are cleared at the end of the execution
+   // marks for state management in maps
+   std::map<int, SalaObj> marks;
+
 public:
    SalaProgram(SalaObj context);
    ~SalaProgram();


### PR DESCRIPTION
This fixes #267, and also a few fatal bugs in salascript that were uncovered when starting to fix this issue. Pretty much a parsing bug in salascript (which caused #267) was hiding the fact that marking objects had been completely broken.
Fixed by tracking the marks on the salaprogram object itself so they don't get reset when recreating the salaobjects. This should be safe as there is only ever one map for one program, so the attribute index of a map element is unique within the context of a salaprogram instance.