### PR TITLE
Agent trails file

### DIFF
--- a/depthmapX/GraphDoc.cpp
+++ b/depthmapX/GraphDoc.cpp
@@ -713,6 +713,79 @@ void QGraphDoc::OnFileExport()
     }
 }
 
+void QGraphDoc::OnFileExportMapGeometry() {
+    if (m_communicator) {
+        QMessageBox::warning(this, tr("Notice"), tr("Sorry, cannot export as another process is running"),
+                             QMessageBox::Ok, QMessageBox::Ok);
+        return; // Locked
+    }
+    if (m_meta_graph->viewingNone()) {
+        QMessageBox::warning(this, tr("Notice"), tr("Sorry, cannot export as there is no data to export"),
+                             QMessageBox::Ok, QMessageBox::Ok);
+        return; // No graph to export
+    }
+
+    QString suffix;
+    int mode = -1;
+
+    int view_class = m_meta_graph->getViewClass();
+    if (view_class & MetaGraph::VIEWAXIAL) {
+        mode = 0;
+        suffix = m_meta_graph->getDisplayedShapeGraph().getName().c_str();
+    } else if (view_class & MetaGraph::VIEWDATA) {
+        mode = 1;
+        suffix = m_meta_graph->getDisplayedDataMap().getName().c_str();
+    }
+
+    if (mode == -1) {
+        QMessageBox::warning(this, tr("Notice"),
+                             tr("Sorry, depthmapX does not support saving the currently displayed layer"),
+                             QMessageBox::Ok, QMessageBox::Ok);
+        return;
+    }
+    suffix.replace(' ', '_');
+
+    QFilePath path(m_opened_name);
+    QString defaultname = path.m_path + (path.m_name.isEmpty() ? windowTitle() : path.m_name) + tr("_") + suffix;
+
+    QString template_string = tr("Chiron and Alasdair Transfer Format file (*.cat)\n");
+
+    QFileDialog::Options options = 0;
+    QString selectedFilter;
+    QString outfile =
+        QFileDialog::getSaveFileName(0, tr("Save Output As"), defaultname, template_string, &selectedFilter, options);
+    if (outfile.isEmpty()) {
+        return;
+    }
+
+    FILE *fp = fopen(outfile.toLatin1(), "wb");
+    fclose(fp);
+
+    QFilePath filepath(outfile);
+    QString ext = filepath.m_ext;
+
+    if (ext == "CAT") {
+        std::ofstream stream(outfile.toLatin1());
+        if (stream.fail() || stream.bad()) {
+            QMessageBox::warning(this, tr("Notice"), tr("Sorry, unable to open file for export"), QMessageBox::Ok,
+                                 QMessageBox::Ok);
+            mode = -1;
+        }
+
+        switch (mode) {
+        case 0:
+            m_meta_graph->writeMapShapesAsCat(m_meta_graph->getDisplayedShapeGraph(), stream);
+            break;
+        case 1:
+            m_meta_graph->writeMapShapesAsCat(m_meta_graph->getDisplayedDataMap(), stream);
+            break;
+        default:
+            break;
+        }
+        stream.close();
+    }
+}
+
 void QGraphDoc::OnFileExportLinks()
 {
     if (m_communicator) {

--- a/depthmapX/GraphDoc.h
+++ b/depthmapX/GraphDoc.h
@@ -271,6 +271,7 @@ public:
     void OnVGALinksFileImport();
     void OnFileImport();
 	void OnFileExport();
+    void OnFileExportMapGeometry();
     void OnFileExportLinks();
     void OnAxialConnectionsExportAsDot();
     void OnAxialConnectionsExportAsPairCSV();

--- a/depthmapX/mainwindow.cpp
+++ b/depthmapX/mainwindow.cpp
@@ -363,6 +363,17 @@ void MainWindow::OnFileExport()
         m_p->OnFileExport();
     }
 }
+
+
+void MainWindow::OnFileExportMapGeometry()
+{
+    QGraphDoc* m_p = activeMapDoc();
+    if(m_p)
+    {
+        m_p->OnFileExportMapGeometry();
+    }
+}
+
 void MainWindow::OnFileExportLinks()
 {
     QGraphDoc* m_p = activeMapDoc();
@@ -2515,6 +2526,7 @@ void MainWindow::updateMapMenu()
         convertMapShapesAct->setEnabled(0);
         importAct->setEnabled(0);
         exportAct->setEnabled(0);
+        exportGeometryAct->setEnabled(false);
         exportLinksAct->setEnabled(0);
         exportAxialConnectionsDotAct->setEnabled(0);
         exportAxialConnectionsPairAct->setEnabled(0);
@@ -2542,6 +2554,7 @@ void MainWindow::updateMapMenu()
     if (!m_p->m_meta_graph->viewingNone() && !m_p->m_communicator)
     {
         exportAct->setEnabled(true);
+        exportGeometryAct->setEnabled(true);
         exportLinksAct->setEnabled(true);
         exportAxialConnectionsDotAct->setEnabled(true);
         exportAxialConnectionsPairAct->setEnabled(true);
@@ -2550,6 +2563,7 @@ void MainWindow::updateMapMenu()
     else
     {
         exportAct->setEnabled(0);
+        exportGeometryAct->setEnabled(false);
         exportLinksAct->setEnabled(0);
         exportAxialConnectionsDotAct->setEnabled(0);
         exportAxialConnectionsPairAct->setEnabled(0);
@@ -2982,6 +2996,10 @@ void MainWindow::createActions()
     exportAct->setShortcut(tr("Ctrl+E"));
     exportAct->setStatusTip(tr("Export the active map"));
     connect(exportAct, SIGNAL(triggered()), this, SLOT(OnFileExport()));
+
+    exportGeometryAct = new QAction(tr("&Export map geometry..."), this);
+    exportGeometryAct->setStatusTip(tr("Export the geometry of the active map"));
+    connect(exportGeometryAct, SIGNAL(triggered()), this, SLOT(OnFileExportMapGeometry()));
 
     exportLinksAct = new QAction(tr("&Export links..."), this);
     exportLinksAct->setStatusTip(tr("Export the links of the active map"));
@@ -3506,6 +3524,7 @@ void MainWindow::createMenus()
     mapMenu->addAction(importAct);
     exportSubMenu = mapMenu->addMenu(tr("&Export"));
     exportSubMenu->addAction(exportAct);
+    exportSubMenu->addAction(exportGeometryAct);
     exportSubMenu->addAction(exportLinksAct);
     exportSubMenu->addAction(exportAxialConnectionsDotAct);
     exportSubMenu->addAction(exportAxialConnectionsPairAct);

--- a/depthmapX/mainwindow.h
+++ b/depthmapX/mainwindow.h
@@ -128,6 +128,7 @@ private slots:
     void OnLayerConvertDrawing();
     void OnConvertMapShapes();
     void OnFileExport();
+    void OnFileExportMapGeometry();
     void OnFileExportLinks();
     void OnAxialConnectionsExportAsDot();
     void OnAxialConnectionsExportAsPairCSV();
@@ -343,6 +344,7 @@ private:
     QAction *convertMapShapesAct;
     QAction *importAct;
     QAction *exportAct;
+    QAction *exportGeometryAct;
     QAction *exportLinksAct;
     QAction *exportAxialConnectionsDotAct;
     QAction *exportAxialConnectionsPairAct;

--- a/depthmapX/renderthread.cpp
+++ b/depthmapX/renderthread.cpp
@@ -435,7 +435,7 @@ void RenderThread::run()
          {
             try {
               pDoc->m_meta_graph->runAgentEngine( comm );
-              pDoc->SetUpdateFlag(QGraphDoc::NEW_DATA);
+              pDoc->SetUpdateFlag(QGraphDoc::NEW_TABLE);
               pDoc->SetRedrawFlag(QGraphDoc::VIEW_ALL, QGraphDoc::REDRAW_POINTS, QGraphDoc::NEW_DATA );
             } catch (depthmapX::PointMapException const & e) {
               emit runtimeExceptionThrown(e.getErrorType(), e.what());

--- a/depthmapXcli/runmethods.cpp
+++ b/depthmapXcli/runmethods.cpp
@@ -496,7 +496,6 @@ namespace dm_runmethods
         // note, trails currently per run, but output per engine
         if (agentP.recordTrailsForAgents() == 0) {
             eng.m_record_trails = true;
-            eng.m_trail_count = MAX_TRAILS;
         }
         else if (agentP.recordTrailsForAgents() > 0) {
                 eng.m_record_trails = true;

--- a/depthmapXcli/runmethods.cpp
+++ b/depthmapXcli/runmethods.cpp
@@ -535,7 +535,8 @@ namespace dm_runmethods
                 case AgentParser::OutputType::TRAILS:
                 {
                     std::ofstream trailStream(cmdP.getOuputFile().c_str());
-                    DO_TIMED("Writing trails", eng.outputTrails(trailStream))
+                    ShapeMap trailMap = eng.getTrailsAsMap();
+                    DO_TIMED("Writing trails", mgraph->writeMapShapesAsCat(trailMap, trailStream))
                     break;
                 }
             }
@@ -560,7 +561,8 @@ namespace dm_runmethods
             if(std::find(resultTypes.begin(), resultTypes.end(), AgentParser::OutputType::TRAILS) != resultTypes.end()) {
                 std::string outFile = cmdP.getOuputFile() + "_trails.cat";
                 std::ofstream trailStream(outFile.c_str());
-                 DO_TIMED("Writing trails", eng.outputTrails(trailStream))
+                ShapeMap trailMap = eng.getTrailsAsMap();
+                DO_TIMED("Writing trails", mgraph->writeMapShapesAsCat(trailMap, trailStream))
             }
         }
     }

--- a/salalib/mgraph.cpp
+++ b/salalib/mgraph.cpp
@@ -1463,16 +1463,16 @@ void MetaGraph::writeMapShapesAsCat(ShapeMap& map, std::ostream &stream) {
     for (auto refShape: map.getAllShapes()) {
         SalaShape& shape = refShape.second;
         if(shape.isPolyLine() || shape.isPolygon()) {
-            stream << "begin " << (shape.isPolyLine() ? "polyline" : "polygon") << std::endl;
+            stream << "Begin " << (shape.isPolyLine() ? "Polyline" : "Polygon") << std::endl;
             for (Point2f p: shape.m_points) {
                 stream << p.x << " " << p.y << std::endl;
             }
-            stream << "end " << (shape.isPolyLine() ? "polyline" : "polygon") << std::endl;
+            stream << "End " << (shape.isPolyLine() ? "Polyline" : "Polygon") << std::endl;
         } else if(shape.isLine()) {
-            stream << "begin polyline" << std::endl;
+            stream << "Begin Polyline" << std::endl;
             stream << shape.getLine().ax() << " " << shape.getLine().ay() << std::endl;
             stream << shape.getLine().bx() << " " << shape.getLine().by() << std::endl;
-            stream << "end polyline" << std::endl;
+            stream << "End Polyline" << std::endl;
         }
     }
 }

--- a/salalib/mgraph.cpp
+++ b/salalib/mgraph.cpp
@@ -1455,6 +1455,28 @@ int MetaGraph::loadLineData( Communicator *communicator, int load_type )
    return 1;
 }
 
+// From: Alasdair Turner (2004) - Depthmap 4: a researcher's handbook (p. 6):
+// [..] CAT, which stands for Chiron and Alasdair Transfer Format [..]
+
+void MetaGraph::writeMapShapesAsCat(ShapeMap& map, std::ostream &stream) {
+    stream << "CAT" << std::endl;
+    for (auto refShape: map.getAllShapes()) {
+        SalaShape& shape = refShape.second;
+        if(shape.isPolyLine() || shape.isPolygon()) {
+            stream << "begin " << (shape.isPolyLine() ? "polyline" : "polygon") << std::endl;
+            for (Point2f p: shape.m_points) {
+                stream << p.x << " " << p.y << std::endl;
+            }
+            stream << "end " << (shape.isPolyLine() ? "polyline" : "polygon") << std::endl;
+        } else if(shape.isLine()) {
+            stream << "begin polyline" << std::endl;
+            stream << shape.getLine().ax() << " " << shape.getLine().ay() << std::endl;
+            stream << shape.getLine().bx() << " " << shape.getLine().by() << std::endl;
+            stream << "end polyline" << std::endl;
+        }
+    }
+}
+
 int MetaGraph::loadCat( std::istream& stream, Communicator *communicator )
 {
    if (communicator) {
@@ -1918,7 +1940,20 @@ void MetaGraph::runAgentEngine(Communicator *comm)
       table.insertColumn(g_col_gate_counts);
    }
 
+
    m_agent_engine.run(comm, &(getDisplayedPointMap()) );
+
+   if(m_agent_engine.m_record_trails) {
+       std::string mapName = "Agent Trails";
+       int count = 1;
+       while(std::find_if(std::begin(m_dataMaps), std::end(m_dataMaps),
+                          [&] (ShapeMap const& m) {return m.getName() == mapName; }) != m_dataMaps.end()) {
+           mapName = "Agent Trails " + std::to_string(count);
+           count++;
+       }
+       m_dataMaps.push_back(m_agent_engine.getTrailsAsMap(mapName));
+       m_state |= DATAMAPS;
+   }
 
    if (m_agent_engine.m_gatelayer != -1) {
       // switch column counts from vga layer to gates layer...

--- a/salalib/mgraph.h
+++ b/salalib/mgraph.h
@@ -146,6 +146,7 @@ public:
       { m_state = state; }
 
    int loadLineData( Communicator *communicator, int load_type );
+   void writeMapShapesAsCat(ShapeMap& map, std::ostream &stream);
    int loadCat( std::istream& stream, Communicator *communicator );
    int loadRT1(const std::vector<std::string>& fileset, Communicator *communicator);
    ShapeMap &createNewShapeMap(depthmapX::ImportType mapType, std::string name);

--- a/salalib/nagent.cpp
+++ b/salalib/nagent.cpp
@@ -149,27 +149,16 @@ void AgentEngine::run(Communicator *comm, PointMap *pointmap)
       }
    }
 
-   // output agent trails to file:
-   if (m_record_trails) {
-       // just dump in local file...
-       std::ofstream trails("trails.cat");
-       outputTrails(trails);
-   }
-
-   // actually, no, do this from the 
    pointmap->overrideDisplayedAttribute(-2);
    pointmap->setDisplayedAttribute(displaycol);
 }
 
-void AgentEngine::outputTrails(std::ostream& trailsFile) {
-    trailsFile << "CAT" << std::endl;
+ShapeMap AgentEngine::getTrailsAsMap(std::string mapName) {
+    ShapeMap trailsMap(mapName, ShapeMap::DATAMAP);
     for (int i = 0; i < m_trail_count; i++) {
-       trailsFile << "Begin Polyline" << std::endl;
-       for (size_t j = 0; j < g_trails[i].size(); j++) {
-          trailsFile << g_trails[i][j].x << " " << g_trails[i][j].y << std::endl;
-       }
-       trailsFile << "End Polyline" << std::endl;
+        trailsMap.makePolyShape(g_trails[i], true, false);
     }
+    return(trailsMap);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/salalib/nagent.cpp
+++ b/salalib/nagent.cpp
@@ -96,7 +96,7 @@ void AgentEngine::run(Communicator *comm, PointMap *pointmap)
          m_trail_count = 1;
       }
       for (auto& agentSet: agentSets) {
-        agentSet.m_trails = std::vector<std::vector<Point2f>>(m_trail_count);
+        agentSet.m_trails = std::vector<std::vector<Event2f>>(m_trail_count);
       }
       trail_num = 0;
    } else {
@@ -153,14 +153,15 @@ void AgentEngine::run(Communicator *comm, PointMap *pointmap)
 
 ShapeMap AgentEngine::getTrailsAsMap(std::string mapName) {
     ShapeMap trailsMap(mapName, ShapeMap::DATAMAP);
-    for (int i = 0; i < m_trail_count; i++) {
-        for (auto& agentSet: agentSets) {
-            // there is currently only one AgentSet. If at any point there are more then
-            // this could be amended to put the AgentSet id as a property of the agent
-            trailsMap.makePolyShape(agentSet.m_trails[i], true, false);
+    for (auto &agentSet : agentSets) {
+        // there is currently only one AgentSet. If at any point there are more then
+        // this could be amended to put the AgentSet id as a property of the trail
+        for (auto &trail : agentSet.m_trails) {
+            std::vector<Point2f> trailGeometry(trail.begin(), trail.end());
+            trailsMap.makePolyShape(trailGeometry, true, false);
         }
     }
-    return(trailsMap);
+    return (trailsMap);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
@@ -711,7 +712,7 @@ void Agent::onStep()
       m_loc = nextloc;
    }
    if (!m_stopped && m_trail_num != -1) {
-      m_program->m_trails[m_trail_num].push_back(m_loc);
+      m_program->m_trails[m_trail_num].push_back(Event2f(m_loc, m_program->m_steps));
    }
 }
 bool Agent::diagonalStep() 

--- a/salalib/nagent.h
+++ b/salalib/nagent.h
@@ -191,7 +191,7 @@ struct AgentProgram
    // to reload later:
    void save(const std::string& filename);
    bool open(const std::string& filename);
-   std::vector<std::vector<Point2f>> m_trails;
+   std::vector<std::vector<Event2f>> m_trails;
 };
 
 struct AgentSet : public AgentProgram

--- a/salalib/nagent.h
+++ b/salalib/nagent.h
@@ -130,8 +130,6 @@ struct AgentSet;
 struct AgentProgram;
 class Agent;
 
-const int MAX_TRAILS = 50;
-
 class AgentEngine
 {
 public: // public for now for speed
@@ -140,7 +138,7 @@ public: // public for now for speed
    int m_timesteps;
 public:
    bool m_record_trails;
-   int m_trail_count;
+   int m_trail_count = 50;
 public:
    AgentEngine();
    void run(Communicator *comm, PointMap *pointmap);
@@ -193,6 +191,7 @@ struct AgentProgram
    // to reload later:
    void save(const std::string& filename);
    bool open(const std::string& filename);
+   std::vector<std::vector<Point2f>> m_trails;
 };
 
 struct AgentSet : public AgentProgram

--- a/salalib/nagent.h
+++ b/salalib/nagent.h
@@ -22,6 +22,9 @@
 
 #include "salalib/pixelref.h"
 #include "salalib/point.h"
+#include "salalib/pointdata.h"
+#include "salalib/shapemap.h"
+
 #include "genlib/pflipper.h"
 
 const char g_col_total_counts[] = "Gate Counts";
@@ -141,7 +144,7 @@ public:
 public:
    AgentEngine();
    void run(Communicator *comm, PointMap *pointmap);
-   void outputTrails(std::ostream& trailsFile);
+   ShapeMap getTrailsAsMap(std::string mapName = "Agent Trails");
 };
 
 struct AgentProgram

--- a/salalib/shapemap.h
+++ b/salalib/shapemap.h
@@ -23,6 +23,7 @@
 #include "salalib/attributes.h"
 #include "salalib/spacepix.h"
 #include "salalib/parsers/mapinfodata.h"
+#include "salalib/connector.h"
 
 #include "genlib/bsptree.h"
 #include "genlib/containerutils.h"
@@ -169,8 +170,6 @@ public:
        return lines;
    }
 };
-
-struct Connector;
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Essentially stops the agent analysis from generating a trails.cat file (to store the trails) and puts them instead in a datamap (a simple shapemap).
Exporting that datamap to a CAT file is also included
CAT = Chiron and Alasdair Transfer format, described by Alasdair Turner (2004) - Depthmap 4: a researcher's handbook (p. 6)