### PR TITLE
Make sure there are shapes before accessing first object

### DIFF
--- a/salalib/shapemap.cpp
+++ b/salalib/shapemap.cpp
@@ -2574,7 +2574,7 @@ bool ShapeMap::write( std::ofstream& stream, int version )
 
    // left here for backwards-compatibility
    // TODO: Remove at next iteration of the .graph file format
-   int largest_shape_ref = m_shapes.rbegin()->first;
+   int largest_shape_ref = m_shapes.size() != 0 ? m_shapes.rbegin()->first : -1;
    stream.write((char *) &largest_shape_ref, sizeof(largest_shape_ref));
 
    // write shape data

--- a/salalib/shapemap.cpp
+++ b/salalib/shapemap.cpp
@@ -2574,7 +2574,7 @@ bool ShapeMap::write( std::ofstream& stream, int version )
 
    // left here for backwards-compatibility
    // TODO: Remove at next iteration of the .graph file format
-   int largest_shape_ref = m_shapes.size() != 0 ? m_shapes.rbegin()->first : -1;
+   int largest_shape_ref = m_shapes.empty() ? -1 : m_shapes.rbegin()->first;
    stream.write((char *) &largest_shape_ref, sizeof(largest_shape_ref));
 
    // write shape data


### PR DESCRIPTION
This is still backwards compatible as seen in https://github.com/SpaceGroupUCL/depthmapX/blob/1c9a7c6b8be59638143a9ad3b1a818e374b5c23b/salalib/shapemap.cpp#L2636