### PR TITLE
Make the tooltips show as fixed notation

### DIFF
--- a/depthmapX/views/glview/glview.cpp
+++ b/depthmapX/views/glview/glview.cpp
@@ -538,8 +538,13 @@ bool GLView::eventFilter(QObject *object, QEvent *e)
                     float val = m_pDoc.m_meta_graph->getLocationValue(getWorldPoint(helpEvent->pos()));
                     if (val == -1.0f)
                         setToolTip("No value");
-                    else if (val != -2.0f)
-                        setToolTip(QString("%1").arg(val));
+                    else if (val != -2.0f) {
+                        QString s;
+                        QTextStream txt(&s);
+                        txt.setRealNumberNotation(QTextStream::FixedNotation);
+                        txt << val;
+                        setToolTip(s);
+                    }
                     else setToolTip("");
                 }
             }


### PR DESCRIPTION
The default (scientific notation) is not very useful on tooltip display, especially for the VGA Ref numbers that can become too large