### PR TITLE
Move the options in the analysis modules

### DIFF
--- a/salalib/axialmodules/axialhelpers.h
+++ b/salalib/axialmodules/axialhelpers.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "genlib/stringutils.h"
+#include "salalib/options.h"
 
 #include <vector>
 

--- a/salalib/axialmodules/axialintegration.cpp
+++ b/salalib/axialmodules/axialintegration.cpp
@@ -22,7 +22,7 @@
 #include "genlib/pflipper.h"
 #include "genlib/stringutils.h"
 
-bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) {
+bool AxialIntegration::run(Communicator *comm, ShapeGraph &map, bool simple_version) {
     // note, from 10.0, Depthmap no longer includes *self* connections on axial lines
     // self connections are stripped out on loading graph files, as well as no longer made
 
@@ -38,7 +38,7 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
     // ...to ensure no mess ups, we'll re-sort here:
     bool radius_n = false;
     std::vector<int> radii;
-    for (double radius : options.radius_set) {
+    for (double radius : m_radius_set) {
         if (radius < 0) {
             radius_n = true;
         } else {
@@ -52,10 +52,10 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
     // retrieve weighted col data, as this may well be overwritten in the new analysis:
     std::vector<double> weights;
     std::string weighting_col_text;
-    if (options.weighted_measure_col != -1) {
-        weighting_col_text = attributes.getColumnName(options.weighted_measure_col);
+    if (m_weighted_measure_col != -1) {
+        weighting_col_text = attributes.getColumnName(m_weighted_measure_col);
         for (size_t i = 0; i < map.getShapeCount(); i++) {
-            weights.push_back(map.getAttributeRowFromShapeIndex(i).getValue(options.weighted_measure_col));
+            weights.push_back(map.getAttributeRowFromShapeIndex(i).getValue(m_weighted_measure_col));
         }
     }
 
@@ -65,12 +65,12 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
         if (radius != -1) {
             radius_text = dXstring::formatString(radius, " R%d");
         }
-        if (options.choice) {
+        if (m_choice) {
             std::string choice_col_text = std::string("Choice") + radius_text;
             attributes.insertOrResetColumn(choice_col_text.c_str());
             std::string n_choice_col_text = std::string("Choice [Norm]") + radius_text;
             attributes.insertOrResetColumn(n_choice_col_text.c_str());
-            if (options.weighted_measure_col != -1) {
+            if (m_weighted_measure_col != -1) {
                 std::string w_choice_col_text = std::string("Choice [") + weighting_col_text + " Wgt]" + radius_text;
                 attributes.insertOrResetColumn(w_choice_col_text.c_str());
                 std::string nw_choice_col_text =
@@ -108,13 +108,13 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
             attributes.insertOrResetColumn(rel_entropy_col_text);
         }
 
-        if (options.weighted_measure_col != -1) {
+        if (m_weighted_measure_col != -1) {
             std::string w_md_col_text = std::string("Mean Depth [") + weighting_col_text + " Wgt]" + radius_text;
             attributes.insertOrResetColumn(w_md_col_text.c_str());
             std::string total_weight_text = std::string("Total ") + weighting_col_text + radius_text;
             attributes.insertOrResetColumn(total_weight_text.c_str());
         }
-        if (options.fulloutput) {
+        if (m_fulloutput) {
             if (!simple_version) {
                 std::string penn_norm_text = std::string("RA [Penn]") + radius_text;
                 attributes.insertOrResetColumn(penn_norm_text);
@@ -132,7 +132,7 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
         }
         //
     }
-    if (options.local) {
+    if (m_local) {
         if (!simple_version) {
             attributes.insertOrResetColumn("Control");
             attributes.insertOrResetColumn("Controllability");
@@ -147,12 +147,12 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
         if (radius != -1) {
             radius_text = std::string(" R") + dXstring::formatString(int(radius), "%d");
         }
-        if (options.choice) {
+        if (m_choice) {
             std::string choice_col_text = std::string("Choice") + radius_text;
             choice_col.push_back(attributes.getColumnIndex(choice_col_text.c_str()));
             std::string n_choice_col_text = std::string("Choice [Norm]") + radius_text;
             n_choice_col.push_back(attributes.getColumnIndex(n_choice_col_text.c_str()));
-            if (options.weighted_measure_col != -1) {
+            if (m_weighted_measure_col != -1) {
                 std::string w_choice_col_text = std::string("Choice [") + weighting_col_text + " Wgt]" + radius_text;
                 w_choice_col.push_back(attributes.getColumnIndex(w_choice_col_text.c_str()));
                 std::string nw_choice_col_text =
@@ -189,13 +189,13 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
             rel_entropy_col.push_back(attributes.getColumnIndex(rel_entropy_col_text.c_str()));
         }
 
-        if (options.weighted_measure_col != -1) {
+        if (m_weighted_measure_col != -1) {
             std::string w_md_col_text = std::string("Mean Depth [") + weighting_col_text + " Wgt]" + radius_text;
             w_depth_col.push_back(attributes.getColumnIndex(w_md_col_text.c_str()));
             std::string total_weight_col_text = std::string("Total ") + weighting_col_text + radius_text;
             total_weight_col.push_back(attributes.getColumnIndex(total_weight_col_text.c_str()));
         }
-        if (options.fulloutput) {
+        if (m_fulloutput) {
             std::string ra_col_text = std::string("RA") + radius_text;
             ra_col.push_back(attributes.getColumnIndex(ra_col_text.c_str()));
 
@@ -211,7 +211,7 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
         }
     }
     int control_col, controllability_col;
-    if (options.local) {
+    if (m_local) {
         if (!simple_version) {
             control_col = attributes.getColumnIndex("Control");
             controllability_col = attributes.getColumnIndex("Controllability");
@@ -220,7 +220,7 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
 
     // for choice
     AnalysisInfo **audittrail;
-    if (options.choice) {
+    if (m_choice) {
         audittrail = new AnalysisInfo *[map.getShapeCount()];
         for (size_t i = 0; i < map.getShapeCount(); i++) {
             audittrail[i] = new AnalysisInfo[radii.size()];
@@ -240,14 +240,14 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
         for (size_t j = 0; j < map.getShapeCount(); j++) {
             covered[j] = false;
         }
-        if (options.choice) {
+        if (m_choice) {
             for (size_t k = 0; k < map.getShapeCount(); k++) {
                 audittrail[k][0].previous.ref = -1; // note, 0th member used as radius doesn't matter
                 // note, choice columns are not cleared, but cummulative over all shortest path pairs
             }
         }
 
-        if (options.local) {
+        if (m_local) {
             double control = 0.0;
             const std::vector<int> &connections = map.getConnections()[i].m_connections;
             std::vector<int> totalneighbourhood;
@@ -284,7 +284,7 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
         covered[i] = true;
         int total_depth = 0, depth = 1, node_count = 1, pos = -1, previous = -1; // node_count includes this 1
         double weight = 0.0, rootweight = 0.0, total_weight = 0.0, w_total_depth = 0.0;
-        if (options.weighted_measure_col != -1) {
+        if (m_weighted_measure_col != -1) {
             rootweight = weights[i];
             // include this line in total weights (as per nodecount)
             total_weight += rootweight;
@@ -293,7 +293,7 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
         int r = 0;
         for (int radius : radii) {
             while (foundlist.a().size()) {
-                if (!options.choice) {
+                if (!m_choice) {
                     index = foundlist.a().back().first;
                 } else {
                     pos = pafrand() % foundlist.a().size();
@@ -307,13 +307,13 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
                     if (!covered[line.m_connections[k]]) {
                         covered[line.m_connections[k]] = true;
                         foundlist.b().push_back(std::pair<int, int>(line.m_connections[k], index));
-                        if (options.weighted_measure_col != -1) {
+                        if (m_weighted_measure_col != -1) {
                             // the weight is taken from the discovered node:
                             weight = weights[line.m_connections[k]];
                             total_weight += weight;
                             w_total_depth += depth * weight;
                         }
-                        if (options.choice && previous != -1) {
+                        if (m_choice && previous != -1) {
                             // both directional paths are now recorded for choice
                             // (coincidentally fixes choice problem which was completely wrong)
                             int here = index;   // note: start counting from index as actually looking ahead here
@@ -324,7 +324,7 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
                                     audittrail[here][0].previous.ref; // <- note, just using 0th position: radius for
                                                                       // the previous doesn't matter in this analysis
                             }
-                            if (options.weighted_measure_col != -1) {
+                            if (m_weighted_measure_col != -1) {
                                 // in weighted choice, root node and current node receive values:
                                 audittrail[i][r].weighted_choice += (weight * rootweight) * 0.5;
                                 audittrail[line.m_connections[k]][r].weighted_choice += (weight * rootweight) * 0.5;
@@ -335,7 +335,7 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
                         depthcounts.back() += 1;
                     }
                 }
-                if (!options.choice)
+                if (!m_choice)
                     foundlist.a().pop_back();
                 else
                     foundlist.a().erase(foundlist.a().begin() + pos);
@@ -350,7 +350,7 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
             }
             // set the attributes for this node:
             row.setValue(count_col[r], float(node_count));
-            if (options.weighted_measure_col != -1) {
+            if (m_weighted_measure_col != -1) {
                 row.setValue(total_weight_col[r], float(total_weight));
             }
             // node count > 1 to avoid divide by zero (was > 2)
@@ -358,7 +358,7 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
                 // note -- node_count includes this one -- mean depth as per p.108 Social Logic of Space
                 double mean_depth = double(total_depth) / double(node_count - 1);
                 row.setValue(depth_col[r], float(mean_depth));
-                if (options.weighted_measure_col != -1) {
+                if (m_weighted_measure_col != -1) {
                     // weighted mean depth:
                     row.setValue(w_depth_col[r], float(w_total_depth / total_weight));
                 }
@@ -380,7 +380,7 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
                         }
                     }
 
-                    if (options.fulloutput) {
+                    if (m_fulloutput) {
                         row.setValue(ra_col[r], float(ra));
 
                         if (!simple_version) {
@@ -404,7 +404,7 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
                         row.setValue(integ_pv_col[r], -1.0f);
                         row.setValue(integ_tk_col[r], -1.0f);
                     }
-                    if (options.fulloutput) {
+                    if (m_fulloutput) {
                         row.setValue(ra_col[r], -1.0f);
 
                         if (!simple_version) {
@@ -472,7 +472,7 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
         }
     }
     delete[] covered;
-    if (options.choice) {
+    if (m_choice) {
         i = -1;
         for (auto & iter: attributes) {
             i++;
@@ -485,20 +485,20 @@ bool AxialIntegration::run(Communicator *comm, const Options &options, ShapeGrap
                 // n.b., normalise choice according to (n-1)(n-2)/2 (maximum possible through routes)
                 double node_count = row.getValue(count_col[r]);
                 double total_weight;
-                if (options.weighted_measure_col != -1) {
+                if (m_weighted_measure_col != -1) {
                     total_weight = row.getValue(total_weight_col[r]);
                 }
                 if (node_count > 2) {
                     row.setValue(choice_col[r], float(total_choice));
                     row.setValue(n_choice_col[r], float(2.0 * total_choice / ((node_count - 1) * (node_count - 2))));
-                    if (options.weighted_measure_col != -1) {
+                    if (m_weighted_measure_col != -1) {
                         row.setValue(w_choice_col[r], float(w_total_choice));
                         row.setValue(nw_choice_col[r], float(2.0 * w_total_choice / (total_weight * total_weight)));
                     }
                 } else {
                     row.setValue(choice_col[r], -1);
                     row.setValue(n_choice_col[r], -1);
-                    if (options.weighted_measure_col != -1) {
+                    if (m_weighted_measure_col != -1) {
                         row.setValue(w_choice_col[r], -1);
                         row.setValue(nw_choice_col[r], -1);
                     }

--- a/salalib/axialmodules/axialintegration.h
+++ b/salalib/axialmodules/axialintegration.h
@@ -21,11 +21,18 @@
 #include "salalib/iaxial.h"
 #include "salalib/options.h"
 
-class AxialIntegration : IAxial
-{
-public:
-    std::string getAnalysisName() const override {
-        return "Angular Analysis";
-    }
-    bool run(Communicator *, const Options &, ShapeGraph &map, bool) override;
+class AxialIntegration : IAxial {
+  private:
+    std::set<double> m_radius_set;
+    int m_weighted_measure_col;
+    bool m_choice;
+    bool m_fulloutput;
+    bool m_local;
+
+  public:
+    std::string getAnalysisName() const override { return "Angular Analysis"; }
+    bool run(Communicator *, ShapeGraph &map, bool) override;
+    AxialIntegration(std::set<double> radius_set, int weighted_measure_col, bool choice, bool fulloutput, bool local)
+        : m_radius_set(radius_set), m_weighted_measure_col(weighted_measure_col), m_choice(choice),
+          m_fulloutput(fulloutput), m_local(local) {}
 };

--- a/salalib/axialmodules/axialintegration.h
+++ b/salalib/axialmodules/axialintegration.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/iaxial.h"
-#include "salalib/options.h"
 
 class AxialIntegration : IAxial {
   private:

--- a/salalib/axialmodules/axialstepdepth.cpp
+++ b/salalib/axialmodules/axialstepdepth.cpp
@@ -22,7 +22,7 @@
 #include "genlib/pflipper.h"
 #include "genlib/stringutils.h"
 
-bool AxialStepDepth::run(Communicator *, const Options &, ShapeGraph &map, bool) {
+bool AxialStepDepth::run(Communicator *, ShapeGraph &map, bool) {
 
     AttributeTable &attributes = map.getAttributeTable();
 

--- a/salalib/axialmodules/axialstepdepth.h
+++ b/salalib/axialmodules/axialstepdepth.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/iaxial.h"
-#include "salalib/options.h"
 
 class AxialStepDepth : IAxial
 {

--- a/salalib/axialmodules/axialstepdepth.h
+++ b/salalib/axialmodules/axialstepdepth.h
@@ -27,5 +27,5 @@ public:
     std::string getAnalysisName() const override {
         return "Angular Analysis";
     }
-    bool run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) override;
+    bool run(Communicator *comm, ShapeGraph &map, bool simple_version) override;
 };

--- a/salalib/iaxial.h
+++ b/salalib/iaxial.h
@@ -28,6 +28,6 @@ class IAxial
 {
 public:
     virtual std::string getAnalysisName() const = 0;
-    virtual bool run(Communicator *comm, const Options& options, ShapeGraph &map, bool simple_version) = 0;
+    virtual bool run(Communicator *comm, ShapeGraph &map, bool simple_version) = 0;
     virtual ~IAxial(){}
 };

--- a/salalib/iaxial.h
+++ b/salalib/iaxial.h
@@ -18,7 +18,6 @@
 // Interface to handle different kinds of Axial analysis
 
 #include "salalib/axialmap.h"
-#include "salalib/options.h"
 
 #include "genlib/comm.h"
 

--- a/salalib/isegment.h
+++ b/salalib/isegment.h
@@ -28,7 +28,7 @@ class ISegment
 {
 public:
     virtual std::string getAnalysisName() const = 0;
-    virtual bool run(Communicator *comm, const Options& options, ShapeGraph &map, bool simple_version) = 0;
+    virtual bool run(Communicator *comm, ShapeGraph &map, bool simple_version) = 0;
     virtual ~ISegment(){}
 
     // Axial map helper: convert a radius for angular analysis

--- a/salalib/ivga.h
+++ b/salalib/ivga.h
@@ -18,7 +18,6 @@
 // Interface to handle different kinds of VGA analysis
 
 #include "salalib/mgraph.h"
-#include "salalib/options.h"
 #include "salalib/pointdata.h"
 
 #include "genlib/comm.h"

--- a/salalib/ivga.h
+++ b/salalib/ivga.h
@@ -28,6 +28,6 @@
 class IVGA {
   public:
     virtual std::string getAnalysisName() const = 0;
-    virtual bool run(Communicator *comm, const Options &options, PointMap &map, bool simple_version) = 0;
+    virtual bool run(Communicator *comm, PointMap &map, bool simple_version) = 0;
     virtual ~IVGA() {}
 };

--- a/salalib/mgraph.cpp
+++ b/salalib/mgraph.cpp
@@ -315,7 +315,7 @@ bool MetaGraph::analyseGraph( Communicator *communicator, Options options , bool
          }
          else if (m_view_class & VIEWAXIAL) {
             if (!getDisplayedShapeGraph().isSegmentMap()) {
-                retvar = AxialStepDepth().run(communicator, options, getDisplayedShapeGraph(), false);
+                retvar = AxialStepDepth().run(communicator, getDisplayedShapeGraph(), false);
             }
             else {
                 retvar = SegmentTulipDepth().run(communicator, getDisplayedShapeGraph(), false);
@@ -1278,7 +1278,9 @@ bool MetaGraph::analyseAxial( Communicator *communicator, Options options, bool 
    bool retvar = false;
 
    try {
-      AxialIntegration().run(communicator, options, getDisplayedShapeGraph(), false);
+       AxialIntegration(options.radius_set, options.weighted_measure_col, options.choice, options.fulloutput,
+                        options.local)
+           .run(communicator, getDisplayedShapeGraph(), false);
    } 
    catch (Communicator::CancelledException) {
       retvar = false;

--- a/salalib/mgraph.cpp
+++ b/salalib/mgraph.cpp
@@ -311,7 +311,7 @@ bool MetaGraph::analyseGraph( Communicator *communicator, Options options , bool
       retvar = true;
       if (options.point_depth_selection == 1) {
          if (m_view_class & VIEWVGA) {
-             retvar = VGAVisualGlobalDepth().run(communicator, Options(), getDisplayedPointMap(), false);
+             retvar = VGAVisualGlobalDepth().run(communicator, getDisplayedPointMap(), false);
          }
          else if (m_view_class & VIEWAXIAL) {
             if (!getDisplayedShapeGraph().isSegmentMap()) {
@@ -326,14 +326,14 @@ bool MetaGraph::analyseGraph( Communicator *communicator, Options options , bool
       }
       else if (options.point_depth_selection == 2) {
          if (m_view_class & VIEWVGA) {
-             retvar = VGAMetricDepth().run(communicator, Options(), getDisplayedPointMap(), false);
+             retvar = VGAMetricDepth().run(communicator, getDisplayedPointMap(), false);
          }
          else if (m_view_class & VIEWAXIAL && getDisplayedShapeGraph().isSegmentMap()) {
              retvar = SegmentMetricPD().run(communicator, options, getDisplayedShapeGraph(), false);
          }
       }
       else if (options.point_depth_selection == 3) {
-          retvar = VGAAngularDepth().run(communicator, Options(), getDisplayedPointMap(), false);
+          retvar = VGAAngularDepth().run(communicator, getDisplayedPointMap(), false);
       }
       else if (options.point_depth_selection == 4) {
          if (m_view_class & VIEWVGA) {
@@ -344,27 +344,27 @@ bool MetaGraph::analyseGraph( Communicator *communicator, Options options , bool
          }
       }
       else if (options.output_type == Options::OUTPUT_ISOVIST) {
-         retvar = VGAIsovist().run(communicator, options, getDisplayedPointMap(), simple_version);
+         retvar = VGAIsovist().run(communicator, getDisplayedPointMap(), simple_version);
       }
       else if (options.output_type == Options::OUTPUT_VISUAL) {
           bool localResult = true;
           bool globalResult = true;
           if (options.local) {
-              localResult = VGAVisualLocal().run(communicator, options, getDisplayedPointMap(), simple_version);
+              localResult = VGAVisualLocal(options.gates_only).run(communicator, getDisplayedPointMap(), simple_version);
           }
           if (options.global) {
-              globalResult = VGAVisualGlobal().run(communicator, options, getDisplayedPointMap(), simple_version);
+              globalResult = VGAVisualGlobal(options.radius, options.gates_only).run(communicator, getDisplayedPointMap(), simple_version);
           }
           retvar = globalResult & localResult;
       }
       else if (options.output_type == Options::OUTPUT_METRIC) {
-          retvar = VGAMetric().run(communicator, options, getDisplayedPointMap(), simple_version);
+          retvar = VGAMetric(options.radius, options.gates_only).run(communicator, getDisplayedPointMap(), simple_version);
       }
       else if (options.output_type == Options::OUTPUT_ANGULAR) {
-          retvar = VGAAngular().run(communicator, options, getDisplayedPointMap(), simple_version);
+          retvar = VGAAngular(options.radius, options.gates_only).run(communicator, getDisplayedPointMap(), simple_version);
       }
       else if (options.output_type == Options::OUTPUT_THRU_VISION) {
-          retvar = VGAThroughVision().run(communicator, options, getDisplayedPointMap(), simple_version);
+          retvar = VGAThroughVision().run(communicator, getDisplayedPointMap(), simple_version);
       }
    } 
    catch (Communicator::CancelledException) {
@@ -2044,8 +2044,7 @@ bool MetaGraph::analyseThruVision(Communicator *comm, int gatelayer)
    }
 
    try {
-       Options tempOptions;
-       retvar = VGAThroughVision().run(comm, tempOptions, getDisplayedPointMap(), false);
+       retvar = VGAThroughVision().run(comm, getDisplayedPointMap(), false);
    }
    catch (Communicator::CancelledException) {
       retvar = false;

--- a/salalib/mgraph.cpp
+++ b/salalib/mgraph.cpp
@@ -318,7 +318,7 @@ bool MetaGraph::analyseGraph( Communicator *communicator, Options options , bool
                 retvar = AxialStepDepth().run(communicator, options, getDisplayedShapeGraph(), false);
             }
             else {
-                retvar = SegmentTulipDepth().run(communicator, options, getDisplayedShapeGraph(), false);
+                retvar = SegmentTulipDepth().run(communicator, getDisplayedShapeGraph(), false);
             }
          }
          // REPLACES:
@@ -329,7 +329,7 @@ bool MetaGraph::analyseGraph( Communicator *communicator, Options options , bool
              retvar = VGAMetricDepth().run(communicator, getDisplayedPointMap(), false);
          }
          else if (m_view_class & VIEWAXIAL && getDisplayedShapeGraph().isSegmentMap()) {
-             retvar = SegmentMetricPD().run(communicator, options, getDisplayedShapeGraph(), false);
+             retvar = SegmentMetricPD().run(communicator, getDisplayedShapeGraph(), false);
          }
       }
       else if (options.point_depth_selection == 3) {
@@ -340,7 +340,7 @@ bool MetaGraph::analyseGraph( Communicator *communicator, Options options , bool
             getDisplayedPointMap().binDisplay( communicator );
          }
          else if (m_view_class & VIEWAXIAL && getDisplayedShapeGraph().isSegmentMap()) {
-             retvar = SegmentTopologicalPD().run(communicator, options, getDisplayedShapeGraph(), false);
+             retvar = SegmentTopologicalPD().run(communicator, getDisplayedShapeGraph(), false);
          }
       }
       else if (options.output_type == Options::OUTPUT_ISOVIST) {
@@ -1296,7 +1296,9 @@ bool MetaGraph::analyseSegmentsTulip( Communicator *communicator, Options option
    bool retvar = false;
 
    try {
-       SegmentTulip().run(communicator, options, getDisplayedShapeGraph(), false);
+       SegmentTulip(options.radius_set, options.sel_only, options.tulip_bins, options.weighted_measure_col,
+                    options.radius_type, options.choice)
+           .run(communicator, getDisplayedShapeGraph(), false);
    }
    catch (Communicator::CancelledException) {
       retvar = false;
@@ -1314,7 +1316,7 @@ bool MetaGraph::analyseSegmentsAngular( Communicator *communicator, Options opti
    bool retvar = false;
 
    try {
-       SegmentAngular().run(communicator, options, getDisplayedShapeGraph(), false);
+       SegmentAngular(options.radius_set).run(communicator, getDisplayedShapeGraph(), false);
    }
    catch (Communicator::CancelledException) {
       retvar = false;
@@ -1335,10 +1337,10 @@ bool MetaGraph::analyseTopoMetMultipleRadii( Communicator *communicator, Options
       // note: "output_type" reused for analysis type (either 0 = topological or 1 = metric)
       for(double radius: options.radius_set) {
           if(options.output_type == 0) {
-              if(!SegmentTopological().run(communicator, options, getDisplayedShapeGraph(), false))
+              if(!SegmentTopological(options.radius, options.sel_only).run(communicator, getDisplayedShapeGraph(), false))
                   retvar = false;
           } else {
-              if(!SegmentMetric().run(communicator, options, getDisplayedShapeGraph(), false))
+              if(!SegmentMetric(options.radius, options.sel_only).run(communicator, getDisplayedShapeGraph(), false))
                   retvar = false;
           }
       }
@@ -1361,9 +1363,9 @@ bool MetaGraph::analyseTopoMet( Communicator *communicator, Options options ) //
    try {
       // note: "output_type" reused for analysis type (either 0 = topological or 1 = metric)
        if(options.output_type == 0) {
-           retvar = SegmentTopological().run(communicator, options, getDisplayedShapeGraph(), false);
+           retvar = SegmentTopological(options.radius, options.sel_only).run(communicator, getDisplayedShapeGraph(), false);
        } else {
-           retvar = SegmentMetric().run(communicator, options, getDisplayedShapeGraph(), false);
+           retvar = SegmentMetric(options.radius, options.sel_only).run(communicator, getDisplayedShapeGraph(), false);
        }
    } 
    catch (Communicator::CancelledException) {

--- a/salalib/segmmodules/segmangular.cpp
+++ b/salalib/segmmodules/segmangular.cpp
@@ -20,7 +20,7 @@
 
 #include "genlib/stringutils.h"
 
-bool SegmentAngular::run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) {
+bool SegmentAngular::run(Communicator *comm, ShapeGraph &map, bool simple_version) {
 
     if (map.getMapType() != ShapeMap::SEGMENTMAP) {
         return false;
@@ -38,7 +38,7 @@ bool SegmentAngular::run(Communicator *comm, const Options &options, ShapeGraph 
     // ...to ensure no mess ups, we'll re-sort here:
     bool radius_n = false;
     std::vector<double> radii;
-    for (double radius : options.radius_set) {
+    for (double radius : m_radius_set) {
         if (radius < 0) {
             radius_n = true;
         } else {

--- a/salalib/segmmodules/segmangular.cpp
+++ b/salalib/segmmodules/segmangular.cpp
@@ -17,6 +17,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "salalib/segmmodules/segmangular.h"
+#include "salalib/options.h"
 
 #include "genlib/stringutils.h"
 

--- a/salalib/segmmodules/segmangular.h
+++ b/salalib/segmmodules/segmangular.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/isegment.h"
-#include "salalib/options.h"
 
 class SegmentAngular : ISegment {
   private:

--- a/salalib/segmmodules/segmangular.h
+++ b/salalib/segmmodules/segmangular.h
@@ -22,7 +22,11 @@
 #include "salalib/options.h"
 
 class SegmentAngular : ISegment {
+  private:
+    std::set<double> m_radius_set;
+
   public:
     std::string getAnalysisName() const override { return "Angular Analysis"; }
-    bool run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) override;
+    bool run(Communicator *comm, ShapeGraph &map, bool simple_version) override;
+    SegmentAngular(std::set<double> radius_set) : m_radius_set(radius_set) {}
 };

--- a/salalib/segmmodules/segmmetric.cpp
+++ b/salalib/segmmodules/segmmetric.cpp
@@ -20,7 +20,7 @@
 
 #include "genlib/stringutils.h"
 
-bool SegmentMetric::run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) {
+bool SegmentMetric::run(Communicator *comm, ShapeGraph &map, bool simple_version) {
 
     AttributeTable &attributes = map.getAttributeTable();
 
@@ -31,7 +31,7 @@ bool SegmentMetric::run(Communicator *comm, const Options &options, ShapeGraph &
     if (comm) {
         qtimer(atime, 0);
         comm->CommPostMessage(Communicator::NUM_RECORDS,
-                              (options.sel_only ? map.getSelSet().size() : map.getConnections().size()));
+                              (m_sel_only ? map.getSelSet().size() : map.getConnections().size()));
     }
     int reccount = 0;
 
@@ -53,8 +53,8 @@ bool SegmentMetric::run(Communicator *comm, const Options &options, ShapeGraph &
     int maxbin = 512;
     prefix = "Metric ";
 
-    if (options.radius != -1.0) {
-        suffix = dXstring::formatString(options.radius, " R%.f metric");
+    if (m_radius != -1.0) {
+        suffix = dXstring::formatString(m_radius, " R%.f metric");
     }
     std::string choicecol = prefix + "Choice" + suffix;
     std::string wchoicecol = prefix + "Choice [SLW]" + suffix;
@@ -64,7 +64,7 @@ bool SegmentMetric::run(Communicator *comm, const Options &options, ShapeGraph &
     std::string totalcol = prefix + "Total Nodes" + suffix;
     std::string wtotalcol = prefix + "Total Length" + suffix;
     //
-    if (!options.sel_only) {
+    if (!m_sel_only) {
         attributes.insertOrResetColumn(choicecol.c_str());
         attributes.insertOrResetColumn(wchoicecol.c_str());
     }
@@ -79,7 +79,7 @@ bool SegmentMetric::run(Communicator *comm, const Options &options, ShapeGraph &
     std::vector<TopoMetSegmentChoice> choicevals(map.getShapeCount());
     for (size_t cursor = 0; cursor < map.getShapeCount(); cursor++) {
         AttributeRow& row = map.getAttributeRowFromShapeIndex(cursor);
-        if (options.sel_only && !row.isSelected()) {
+        if (m_sel_only && !row.isSelected()) {
             continue;
         }
         for (size_t i = 0; i < map.getShapeCount(); i++) {
@@ -143,7 +143,7 @@ bool SegmentMetric::run(Communicator *comm, const Options &options, ShapeGraph &
                     audittrail[connected_cursor] =
                         TopoMetSegmentRef(connected_cursor, here.dir, here.dist + length, here.ref);
                     seen[connected_cursor] = segdepth;
-                    if (options.radius == -1 || here.dist + length < options.radius) {
+                    if (m_radius == -1 || here.dist + length < m_radius) {
                         // puts in a suitable bin ahead of us...
                         open++;
                         //
@@ -155,7 +155,7 @@ bool SegmentMetric::run(Communicator *comm, const Options &options, ShapeGraph &
                     // (seenalready: need to check that we're not doing this twice, given the seen can go twice)
 
                     // Quick mod - TV
-                    if (!options.sel_only && connected_cursor > int(cursor) &&
+                    if (!m_sel_only && connected_cursor > int(cursor) &&
                         !seenalready) { // only one way paths, saves doing this twice
                         int subcur = connected_cursor;
                         while (subcur != -1) {
@@ -187,7 +187,7 @@ bool SegmentMetric::run(Communicator *comm, const Options &options, ShapeGraph &
         }
         reccount++;
     }
-    if (!options.sel_only) {
+    if (!m_sel_only) {
         // note, I've stopped sel only from calculating choice values:
         for (size_t cursor = 0; cursor < map.getShapeCount(); cursor++) {
             AttributeRow& row = map.getAttributeRowFromShapeIndex(cursor);
@@ -196,7 +196,7 @@ bool SegmentMetric::run(Communicator *comm, const Options &options, ShapeGraph &
         }
     }
 
-    if (!options.sel_only) {
+    if (!m_sel_only) {
         map.setDisplayedAttribute(attributes.getColumnIndex(choicecol.c_str()));
     } else {
         map.setDisplayedAttribute(attributes.getColumnIndex(meandepthcol.c_str()));

--- a/salalib/segmmodules/segmmetric.h
+++ b/salalib/segmmodules/segmmetric.h
@@ -24,7 +24,12 @@
 #include "salalib/options.h"
 
 class SegmentMetric : ISegment {
+  private:
+    double m_radius;
+    bool m_sel_only;
+
   public:
     std::string getAnalysisName() const override { return "Metric Analysis"; }
-    bool run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) override;
+    bool run(Communicator *comm, ShapeGraph &map, bool simple_version) override;
+    SegmentMetric(double radius, bool sel_only) : m_radius(radius), m_sel_only(sel_only) {}
 };

--- a/salalib/segmmodules/segmmetric.h
+++ b/salalib/segmmodules/segmmetric.h
@@ -21,7 +21,6 @@
 #include "salalib/segmmodules/segmhelpers.h"
 
 #include "salalib/isegment.h"
-#include "salalib/options.h"
 
 class SegmentMetric : ISegment {
   private:

--- a/salalib/segmmodules/segmmetricpd.cpp
+++ b/salalib/segmmodules/segmmetricpd.cpp
@@ -20,7 +20,7 @@
 
 #include "genlib/stringutils.h"
 
-bool SegmentMetricPD::run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) {
+bool SegmentMetricPD::run(Communicator *comm, ShapeGraph &map, bool simple_version) {
 
     AttributeTable &attributes = map.getAttributeTable();
 

--- a/salalib/segmmodules/segmmetricpd.h
+++ b/salalib/segmmodules/segmmetricpd.h
@@ -26,5 +26,5 @@
 class SegmentMetricPD : ISegment {
   public:
     std::string getAnalysisName() const override { return "Metric Analysis"; }
-    bool run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) override;
+    bool run(Communicator *comm, ShapeGraph &map, bool simple_version) override;
 };

--- a/salalib/segmmodules/segmmetricpd.h
+++ b/salalib/segmmodules/segmmetricpd.h
@@ -21,7 +21,6 @@
 #include "salalib/segmmodules/segmhelpers.h"
 
 #include "salalib/isegment.h"
-#include "salalib/options.h"
 
 class SegmentMetricPD : ISegment {
   public:

--- a/salalib/segmmodules/segmtopological.h
+++ b/salalib/segmmodules/segmtopological.h
@@ -24,7 +24,12 @@
 #include "salalib/options.h"
 
 class SegmentTopological : ISegment {
+  private:
+    double m_radius;
+    bool m_sel_only;
+
   public:
     std::string getAnalysisName() const override { return "Topological Analysis"; }
-    bool run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) override;
+    bool run(Communicator *comm, ShapeGraph &map, bool simple_version) override;
+    SegmentTopological(double radius, bool sel_only) : m_radius(radius), m_sel_only(sel_only) {}
 };

--- a/salalib/segmmodules/segmtopological.h
+++ b/salalib/segmmodules/segmtopological.h
@@ -21,7 +21,6 @@
 #include "salalib/segmmodules/segmhelpers.h"
 
 #include "salalib/isegment.h"
-#include "salalib/options.h"
 
 class SegmentTopological : ISegment {
   private:

--- a/salalib/segmmodules/segmtopologicalpd.cpp
+++ b/salalib/segmmodules/segmtopologicalpd.cpp
@@ -20,7 +20,7 @@
 
 #include "genlib/stringutils.h"
 
-bool SegmentTopologicalPD::run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) {
+bool SegmentTopologicalPD::run(Communicator *comm, ShapeGraph &map, bool simple_version) {
 
     AttributeTable &attributes = map.getAttributeTable();
 

--- a/salalib/segmmodules/segmtopologicalpd.h
+++ b/salalib/segmmodules/segmtopologicalpd.h
@@ -26,5 +26,5 @@
 class SegmentTopologicalPD : ISegment {
   public:
     std::string getAnalysisName() const override { return "Topological Analysis"; }
-    bool run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) override;
+    bool run(Communicator *comm, ShapeGraph &map, bool simple_version) override;
 };

--- a/salalib/segmmodules/segmtopologicalpd.h
+++ b/salalib/segmmodules/segmtopologicalpd.h
@@ -21,7 +21,6 @@
 #include "salalib/segmmodules/segmhelpers.h"
 
 #include "salalib/isegment.h"
-#include "salalib/options.h"
 
 class SegmentTopologicalPD : ISegment {
   public:

--- a/salalib/segmmodules/segmtulip.h
+++ b/salalib/segmmodules/segmtulip.h
@@ -21,11 +21,20 @@
 #include "salalib/isegment.h"
 #include "salalib/options.h"
 
-class SegmentTulip : ISegment
-{
-public:
-    std::string getAnalysisName() const override {
-        return "Tulip Analysis";
-    }
-    bool run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) override;
+class SegmentTulip : ISegment {
+  private:
+    std::set<double> m_radius_set;
+    bool m_sel_only;
+    int m_tulip_bins;
+    int m_weighted_measure_col;
+    int m_radius_type;
+    bool m_choice;
+
+  public:
+    std::string getAnalysisName() const override { return "Tulip Analysis"; }
+    bool run(Communicator *comm, ShapeGraph &map, bool simple_version) override;
+    SegmentTulip(std::set<double> radius_set, bool sel_only, int tulip_bins, int weighted_measure_col, int radius_type,
+                 bool choice)
+        : m_radius_set(radius_set), m_sel_only(sel_only), m_tulip_bins(tulip_bins),
+          m_weighted_measure_col(weighted_measure_col), m_radius_type(radius_type), m_choice(choice) {}
 };

--- a/salalib/segmmodules/segmtulip.h
+++ b/salalib/segmmodules/segmtulip.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/isegment.h"
-#include "salalib/options.h"
 
 class SegmentTulip : ISegment {
   private:

--- a/salalib/segmmodules/segmtulipdepth.cpp
+++ b/salalib/segmmodules/segmtulipdepth.cpp
@@ -22,7 +22,7 @@
 
 // revised to use tulip bins for faster analysis of large spaces
 
-bool SegmentTulipDepth::run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) {
+bool SegmentTulipDepth::run(Communicator *comm, ShapeGraph &map, bool simple_version) {
 
     AttributeTable &attributes = map.getAttributeTable();
 

--- a/salalib/segmmodules/segmtulipdepth.h
+++ b/salalib/segmmodules/segmtulipdepth.h
@@ -27,5 +27,5 @@ public:
     std::string getAnalysisName() const override {
         return "Tulip Analysis";
     }
-    bool run(Communicator *comm, const Options &options, ShapeGraph &map, bool simple_version) override;
+    bool run(Communicator *comm, ShapeGraph &map, bool simple_version) override;
 };

--- a/salalib/segmmodules/segmtulipdepth.h
+++ b/salalib/segmmodules/segmtulipdepth.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/isegment.h"
-#include "salalib/options.h"
 
 class SegmentTulipDepth : ISegment
 {

--- a/salalib/vgamodules/vgaangular.cpp
+++ b/salalib/vgamodules/vgaangular.cpp
@@ -20,7 +20,7 @@
 
 #include "genlib/stringutils.h"
 
-bool VGAAngular::run(Communicator *comm, const Options &options, PointMap &map, bool) {
+bool VGAAngular::run(Communicator *comm, PointMap &map, bool) {
     time_t atime = 0;
     if (comm) {
         qtimer(atime, 0);
@@ -28,13 +28,13 @@ bool VGAAngular::run(Communicator *comm, const Options &options, PointMap &map, 
     }
 
     std::string radius_text;
-    if (options.radius != -1.0) {
+    if (m_radius != -1.0) {
         if (map.getRegion().width() > 100.0) {
-            radius_text = std::string(" R") + dXstring::formatString(options.radius, "%.f");
+            radius_text = std::string(" R") + dXstring::formatString(m_radius, "%.f");
         } else if (map.getRegion().width() < 1.0) {
-            radius_text = std::string(" R") + dXstring::formatString(options.radius, "%.4f");
+            radius_text = std::string(" R") + dXstring::formatString(m_radius, "%.4f");
         } else {
-            radius_text = std::string(" R") + dXstring::formatString(options.radius, "%.2f");
+            radius_text = std::string(" R") + dXstring::formatString(m_radius, "%.2f");
         }
     }
 
@@ -59,7 +59,7 @@ bool VGAAngular::run(Communicator *comm, const Options &options, PointMap &map, 
 
             if (map.getPoint(curs).filled()) {
 
-                if (options.gates_only) {
+                if (m_gates_only) {
                     count++;
                     continue;
                 }
@@ -84,7 +84,7 @@ bool VGAAngular::run(Communicator *comm, const Options &options, PointMap &map, 
                     std::set<AngularTriple>::iterator it = search_list.begin();
                     AngularTriple here = *it;
                     search_list.erase(it);
-                    if (options.radius != -1.0 && here.angle > options.radius) {
+                    if (m_radius != -1.0 && here.angle > m_radius) {
                         break;
                     }
                     Point &p = map.getPoint(here.pixel);

--- a/salalib/vgamodules/vgaangular.h
+++ b/salalib/vgamodules/vgaangular.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/ivga.h"
-#include "salalib/options.h"
 #include "salalib/pixelref.h"
 #include "salalib/pointdata.h"
 

--- a/salalib/vgamodules/vgaangular.h
+++ b/salalib/vgamodules/vgaangular.h
@@ -24,7 +24,12 @@
 #include "salalib/pointdata.h"
 
 class VGAAngular : IVGA {
+  private:
+    double m_radius;
+    bool m_gates_only;
+
   public:
     std::string getAnalysisName() const override { return "Angular Analysis"; }
-    bool run(Communicator *, const Options &, PointMap &map, bool) override;
+    bool run(Communicator *, PointMap &map, bool) override;
+    VGAAngular(double radius, bool gates_only) : m_radius(radius), m_gates_only(gates_only) {}
 };

--- a/salalib/vgamodules/vgaangulardepth.cpp
+++ b/salalib/vgamodules/vgaangulardepth.cpp
@@ -20,7 +20,7 @@
 
 #include "genlib/stringutils.h"
 
-bool VGAAngularDepth::run(Communicator *, const Options &, PointMap &map, bool) {
+bool VGAAngularDepth::run(Communicator *, PointMap &map, bool) {
 
     AttributeTable &attributes = map.getAttributeTable();
 

--- a/salalib/vgamodules/vgaangulardepth.h
+++ b/salalib/vgamodules/vgaangulardepth.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/ivga.h"
-#include "salalib/options.h"
 #include "salalib/pixelref.h"
 #include "salalib/pointdata.h"
 

--- a/salalib/vgamodules/vgaangulardepth.h
+++ b/salalib/vgamodules/vgaangulardepth.h
@@ -26,5 +26,5 @@
 class VGAAngularDepth : IVGA {
   public:
     std::string getAnalysisName() const override { return "Angular Depth"; }
-    bool run(Communicator *comm, const Options &options, PointMap &map, bool) override;
+    bool run(Communicator *comm, PointMap &map, bool) override;
 };

--- a/salalib/vgamodules/vgaisovist.cpp
+++ b/salalib/vgamodules/vgaisovist.cpp
@@ -21,7 +21,7 @@
 
 #include "genlib/stringutils.h"
 
-bool VGAIsovist::run(Communicator *comm, const Options &, PointMap &map, bool simple_version) {
+bool VGAIsovist::run(Communicator *comm, PointMap &map, bool simple_version) {
     map.m_hasIsovistAnalysis = false;
     // note, BSP tree plays with comm counting...
     comm->CommPostMessage(Communicator::NUM_STEPS, 2);

--- a/salalib/vgamodules/vgaisovist.h
+++ b/salalib/vgamodules/vgaisovist.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/ivga.h"
-#include "salalib/options.h"
 #include "salalib/pixelref.h"
 #include "salalib/pointdata.h"
 

--- a/salalib/vgamodules/vgaisovist.h
+++ b/salalib/vgamodules/vgaisovist.h
@@ -26,6 +26,6 @@
 class VGAIsovist : IVGA {
   public:
     std::string getAnalysisName() const override { return "Isovist Analysis"; }
-    bool run(Communicator *comm, const Options &, PointMap &map, bool simple_version) override;
+    bool run(Communicator *comm, PointMap &map, bool simple_version) override;
     BSPNode makeBSPtree(Communicator *communicator, const std::vector<SpacePixelFile> &drawingFiles);
 };

--- a/salalib/vgamodules/vgametric.cpp
+++ b/salalib/vgamodules/vgametric.cpp
@@ -23,7 +23,7 @@
 // This is a slow algorithm, but should give the correct answer
 // for demonstrative purposes
 
-bool VGAMetric::run(Communicator *comm, const Options &options, PointMap &map, bool) {
+bool VGAMetric::run(Communicator *comm, PointMap &map, bool) {
     time_t atime = 0;
     if (comm) {
         qtimer(atime, 0);
@@ -31,13 +31,13 @@ bool VGAMetric::run(Communicator *comm, const Options &options, PointMap &map, b
     }
 
     std::string radius_text;
-    if (options.radius != -1.0) {
-        if (options.radius > 100.0) {
-            radius_text = std::string(" R") + dXstring::formatString(options.radius, "%.f");
+    if (m_radius != -1.0) {
+        if (m_radius > 100.0) {
+            radius_text = std::string(" R") + dXstring::formatString(m_radius, "%.f");
         } else if (map.getRegion().width() < 1.0) {
-            radius_text = std::string(" R") + dXstring::formatString(options.radius, "%.4f");
+            radius_text = std::string(" R") + dXstring::formatString(m_radius, "%.4f");
         } else {
-            radius_text = std::string(" R") + dXstring::formatString(options.radius, "%.2f");
+            radius_text = std::string(" R") + dXstring::formatString(m_radius, "%.2f");
         }
     }
     AttributeTable &attributes = map.getAttributeTable();
@@ -60,7 +60,7 @@ bool VGAMetric::run(Communicator *comm, const Options &options, PointMap &map, b
 
             if (map.getPoint(curs).filled()) {
 
-                if (options.gates_only) {
+                if (m_gates_only) {
                     count++;
                     continue;
                 }
@@ -86,7 +86,7 @@ bool VGAMetric::run(Communicator *comm, const Options &options, PointMap &map, b
                     std::set<MetricTriple>::iterator it = search_list.begin();
                     MetricTriple here = *it;
                     search_list.erase(it);
-                    if (options.radius != -1.0 && (here.dist * map.getSpacing()) > options.radius) {
+                    if (m_radius != -1.0 && (here.dist * map.getSpacing()) > m_radius) {
                         break;
                     }
                     Point &p = map.getPoint(here.pixel);

--- a/salalib/vgamodules/vgametric.h
+++ b/salalib/vgamodules/vgametric.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/ivga.h"
-#include "salalib/options.h"
 #include "salalib/pixelref.h"
 #include "salalib/pointdata.h"
 

--- a/salalib/vgamodules/vgametric.h
+++ b/salalib/vgamodules/vgametric.h
@@ -24,7 +24,12 @@
 #include "salalib/pointdata.h"
 
 class VGAMetric : IVGA {
+  private:
+    double m_radius;
+    bool m_gates_only;
+
   public:
     std::string getAnalysisName() const override { return "Metric Analysis"; }
-    bool run(Communicator *comm, const Options &options, PointMap &map, bool) override;
+    bool run(Communicator *comm, PointMap &map, bool) override;
+    VGAMetric(double radius, bool gates_only) : m_radius(radius), m_gates_only(gates_only) {}
 };

--- a/salalib/vgamodules/vgametricdepth.cpp
+++ b/salalib/vgamodules/vgametricdepth.cpp
@@ -20,7 +20,7 @@
 
 #include "genlib/stringutils.h"
 
-bool VGAMetricDepth::run(Communicator *comm, const Options &options, PointMap &map, bool) {
+bool VGAMetricDepth::run(Communicator *comm, PointMap &map, bool) {
 
     AttributeTable &attributes = map.getAttributeTable();
 

--- a/salalib/vgamodules/vgametricdepth.h
+++ b/salalib/vgamodules/vgametricdepth.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/ivga.h"
-#include "salalib/options.h"
 #include "salalib/pixelref.h"
 #include "salalib/pointdata.h"
 

--- a/salalib/vgamodules/vgametricdepth.h
+++ b/salalib/vgamodules/vgametricdepth.h
@@ -26,5 +26,5 @@
 class VGAMetricDepth : IVGA {
   public:
     std::string getAnalysisName() const override { return "Metric Depth"; }
-    bool run(Communicator *comm, const Options &options, PointMap &map, bool) override;
+    bool run(Communicator *comm, PointMap &map, bool) override;
 };

--- a/salalib/vgamodules/vgathroughvision.cpp
+++ b/salalib/vgamodules/vgathroughvision.cpp
@@ -24,7 +24,7 @@
 // This is a slow algorithm, but should give the correct answer
 // for demonstrative purposes
 
-bool VGAThroughVision::run(Communicator *comm, const Options &, PointMap &map, bool) {
+bool VGAThroughVision::run(Communicator *comm, PointMap &map, bool) {
     time_t atime = 0;
     if (comm) {
         qtimer(atime, 0);

--- a/salalib/vgamodules/vgathroughvision.h
+++ b/salalib/vgamodules/vgathroughvision.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/ivga.h"
-#include "salalib/options.h"
 #include "salalib/pixelref.h"
 #include "salalib/pointdata.h"
 

--- a/salalib/vgamodules/vgathroughvision.h
+++ b/salalib/vgamodules/vgathroughvision.h
@@ -26,5 +26,5 @@
 class VGAThroughVision : IVGA {
   public:
     std::string getAnalysisName() const override { return "Through Vision Analysis"; }
-    bool run(Communicator *comm, const Options &, PointMap &map, bool) override;
+    bool run(Communicator *comm, PointMap &map, bool) override;
 };

--- a/salalib/vgamodules/vgavisualglobal.cpp
+++ b/salalib/vgamodules/vgavisualglobal.cpp
@@ -20,7 +20,7 @@
 
 #include "genlib/stringutils.h"
 
-bool VGAVisualGlobal::run(Communicator *comm, const Options &options, PointMap &map, bool simple_version) {
+bool VGAVisualGlobal::run(Communicator *comm, PointMap &map, bool simple_version) {
     time_t atime = 0;
     if (comm) {
         qtimer(atime, 0);
@@ -30,8 +30,8 @@ bool VGAVisualGlobal::run(Communicator *comm, const Options &options, PointMap &
 
     int entropy_col, rel_entropy_col, integ_dv_col, integ_pv_col, integ_tk_col, depth_col, count_col;
     std::string radius_text;
-    if (options.radius != -1) {
-        radius_text = std::string(" R") + dXstring::formatString(int(options.radius), "%d");
+    if (m_radius != -1) {
+        radius_text = std::string(" R") + dXstring::formatString(int(m_radius), "%d");
     }
 
     // n.b. these must be entered in alphabetical order to preserve col indexing:
@@ -71,7 +71,7 @@ bool VGAVisualGlobal::run(Communicator *comm, const Options &options, PointMap &
             PixelRef curs = PixelRef(i, j);
             if (map.getPoint(curs).filled()) {
 
-                if ((map.getPoint(curs).contextfilled() && !curs.iseven()) || (options.gates_only)) {
+                if ((map.getPoint(curs).contextfilled() && !curs.iseven()) || (m_gates_only)) {
                     count++;
                     continue;
                 }
@@ -103,8 +103,8 @@ bool VGAVisualGlobal::run(Communicator *comm, const Options &options, PointMap &
                             total_depth += level;
                             total_nodes += 1;
                             distribution.back() += 1;
-                            if ((int)options.radius == -1 ||
-                                level < (int)options.radius &&
+                            if ((int)m_radius == -1 ||
+                                level < (int)m_radius &&
                                     (!p.contextfilled() || currLvlIter->iseven())) {
                                 extractUnseen(p.getNode(), search_tree[level + 1], miscs, extents);
                                 pmisc = ~0;

--- a/salalib/vgamodules/vgavisualglobal.h
+++ b/salalib/vgamodules/vgavisualglobal.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/ivga.h"
-#include "salalib/options.h"
 #include "salalib/pixelref.h"
 #include "salalib/pointdata.h"
 

--- a/salalib/vgamodules/vgavisualglobal.h
+++ b/salalib/vgamodules/vgavisualglobal.h
@@ -26,9 +26,14 @@
 #include "genlib/simplematrix.h"
 
 class VGAVisualGlobal : IVGA {
+  private:
+    double m_radius;
+    bool m_gates_only;
+
   public:
     std::string getAnalysisName() const override { return "Global Visibility Analysis"; }
-    bool run(Communicator *comm, const Options &options, PointMap &map, bool simple_version) override;
+    bool run(Communicator *comm, PointMap &map, bool simple_version) override;
     void extractUnseen(Node &node, PixelRefVector &pixels, depthmapX::RowMatrix<int> &miscs,
                        depthmapX::RowMatrix<PixelRef> &extents);
+    VGAVisualGlobal(double radius, bool gates_only) : m_radius(radius), m_gates_only(gates_only) {}
 };

--- a/salalib/vgamodules/vgavisualglobaldepth.cpp
+++ b/salalib/vgamodules/vgavisualglobaldepth.cpp
@@ -20,7 +20,7 @@
 
 #include "genlib/stringutils.h"
 
-bool VGAVisualGlobalDepth::run(Communicator *, const Options &, PointMap &map, bool) {
+bool VGAVisualGlobalDepth::run(Communicator *, PointMap &map, bool) {
 
     AttributeTable &attributes = map.getAttributeTable();
 

--- a/salalib/vgamodules/vgavisualglobaldepth.h
+++ b/salalib/vgamodules/vgavisualglobaldepth.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/ivga.h"
-#include "salalib/options.h"
 #include "salalib/pixelref.h"
 #include "salalib/pointdata.h"
 

--- a/salalib/vgamodules/vgavisualglobaldepth.h
+++ b/salalib/vgamodules/vgavisualglobaldepth.h
@@ -28,7 +28,7 @@
 class VGAVisualGlobalDepth : IVGA {
   public:
     std::string getAnalysisName() const override { return "Global Visibility Depth"; }
-    bool run(Communicator *comm, const Options &options, PointMap &map, bool simple_version) override;
+    bool run(Communicator *comm, PointMap &map, bool simple_version) override;
     void extractUnseen(Node &node, PixelRefVector &pixels, depthmapX::RowMatrix<int> &miscs,
                        depthmapX::RowMatrix<PixelRef> &extents);
 };

--- a/salalib/vgamodules/vgavisuallocal.cpp
+++ b/salalib/vgamodules/vgavisuallocal.cpp
@@ -20,7 +20,7 @@
 
 #include "genlib/stringutils.h"
 
-bool VGAVisualLocal::run(Communicator *comm, const Options &options, PointMap &map, bool simple_version) {
+bool VGAVisualLocal::run(Communicator *comm, PointMap &map, bool simple_version) {
     time_t atime = 0;
     if (comm) {
         qtimer(atime, 0);
@@ -40,7 +40,7 @@ bool VGAVisualLocal::run(Communicator *comm, const Options &options, PointMap &m
         for (size_t j = 0; j < map.getRows(); j++) {
             PixelRef curs = PixelRef(static_cast<short>(i), static_cast<short>(j));
             if (map.getPoint(curs).filled()) {
-                if ((map.getPoint(curs).contextfilled() && !curs.iseven()) || (options.gates_only)) {
+                if ((map.getPoint(curs).contextfilled() && !curs.iseven()) || (m_gates_only)) {
                     count++;
                     continue;
                 }

--- a/salalib/vgamodules/vgavisuallocal.h
+++ b/salalib/vgamodules/vgavisuallocal.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "salalib/ivga.h"
-#include "salalib/options.h"
 #include "salalib/pixelref.h"
 #include "salalib/pointdata.h"
 

--- a/salalib/vgamodules/vgavisuallocal.h
+++ b/salalib/vgamodules/vgavisuallocal.h
@@ -24,7 +24,11 @@
 #include "salalib/pointdata.h"
 
 class VGAVisualLocal : IVGA {
+  private:
+    bool m_gates_only;
+
   public:
     std::string getAnalysisName() const override { return "Local Visibility Analysis"; }
-    bool run(Communicator *comm, const Options &options, PointMap &map, bool simple_version) override;
+    bool run(Communicator *comm, PointMap &map, bool simple_version) override;
+    VGAVisualLocal(bool gates_only) : m_gates_only(gates_only) {}
 };


### PR DESCRIPTION
Makes them independent of the Options object that seems to hold every single possible option required until now. With this PR it will also be easier to reason about which module requires which option. Not sure whether they should all be given in the constructor though...

Eventually these analysis modules could be constructed individually potentially each given its own options dialog/cli mode.