### PR TITLE
Move the progress check inside the filled-point test

### DIFF
--- a/salalib/vgamodules/vgavisualglobal.cpp
+++ b/salalib/vgamodules/vgavisualglobal.cpp
@@ -189,15 +189,14 @@ bool VGAVisualGlobal::run(Communicator *comm, PointMap &map, bool simple_version
                         row.setValue(rel_entropy_col, (float)-1);
                     }
                 }
-            }
-
-            count++; // <- increment count
-            if (comm) {
-                if (qtimer(atime, 500)) {
-                    if (comm->IsCancelled()) {
-                        throw Communicator::CancelledException();
+                count++; // <- increment count
+                if (comm) {
+                    if (qtimer(atime, 500)) {
+                        if (comm->IsCancelled()) {
+                            throw Communicator::CancelledException();
+                        }
+                        comm->CommPostMessage(Communicator::CURRENT_RECORD, count);
                     }
-                    comm->CommPostMessage(Communicator::CURRENT_RECORD, count);
                 }
             }
         }


### PR DESCRIPTION
Otherwise the progress dialog runs out much faster because the whole grid is tested