### PR TITLE
Only unmerge merged pixels

### DIFF
--- a/salalib/pointdata.cpp
+++ b/salalib/pointdata.cpp
@@ -1644,7 +1644,10 @@ bool PointMap::unmergePoints()
    }
    for (auto& sel: m_selection_set) {
       PixelRef a = sel;
-      unmergePixel(a);
+      Point p = getPoint(a);
+      if(p.getMergePixel() != NoPixel) {
+        unmergePixel(a);
+      }
    }
    clearSel();
    return true;


### PR DESCRIPTION
Otherwise the app crashes in multiple unmerges (multiple pixels selected with "unlink")