### PR TITLE
Fix pointmap connections export

### DIFF
--- a/salalib/ngraph.cpp
+++ b/salalib/ngraph.cpp
@@ -389,15 +389,6 @@ bool Bin::containsPoint(const PixelRef p) const
 
 ///////////////////////////////////////////////////////////////////////////////////////
 
-void Bin::contents(PixelRefVector& hood)
-{
-   first();
-   while (!is_tail()) {
-      depthmapX::addIfNotExists(hood, m_curpix);
-      next();
-   }
-}
-
 void Bin::first() const
 {
    m_curvec = 0;

--- a/salalib/ngraph.h
+++ b/salalib/ngraph.h
@@ -81,7 +81,6 @@ protected:
    mutable int m_curvec;
    mutable PixelRef m_curpix;
 public:
-   void contents(PixelRefVector& hood);
    void first() const;
    void next() const;
    bool is_tail() const;

--- a/salalib/pointdata.cpp
+++ b/salalib/pointdata.cpp
@@ -666,16 +666,13 @@ void PointMap::outputConnectionsAsCSV(std::ostream& myout, std::string delim)
             {
                 PixelRef pix(i,j);
                 seenPix.insert(pix);
-                for (int b = 0; b < 32; b++)
+                PixelRefVector hood;
+                pnt.m_node->contents(hood);
+                for(PixelRef &p: hood)
                 {
-                    PixelRefVector hood;
-                    pnt.m_node->bin(b).contents(hood);
-                    for(size_t p = 0; p < hood.size(); p++)
+                    if(!(std::find(seenPix.begin(), seenPix.end(), p) != seenPix.end()) && getPoint(p).filled())
                     {
-                        if(!(std::find(seenPix.begin(), seenPix.end(), hood[p]) != seenPix.end()))
-                        {
-                            myout << std::endl << pix << delim << hood[p];
-                        }
+                        myout << std::endl << pix << delim << p;
                     }
                 }
             }
@@ -1406,7 +1403,7 @@ bool PointMap::sparkPixel2(PixelRef curs, int make, double maxdist)
       // from immediately around centre
       // note regionate border must be greater than tolerance squared used in interection testing later
       double border = m_spacing * 1e-10;
-      QtRegion viewport0 = regionate(curs, 1e-10); 
+      QtRegion viewport0 = regionate(curs, 1e-10);
       switch (q) {
       case 0:
          viewport0.top_right.x = centre0.x;


### PR DESCRIPTION
By making sure that only filled points are exported and switch to using the Node::contents() function which performs more checks than the Bin::contents() one

Fixes #124 