### PR TITLE
Make sure keys are also removed when cleaning up lines

### DIFF
--- a/salaTest/CMakeLists.txt
+++ b/salaTest/CMakeLists.txt
@@ -20,7 +20,8 @@ set(salaTest_SRCS
     testgeometrygenerators.cpp
     testmapinfodata.cpp
     testsalaprogram.cpp
-    testdxfp.cpp)
+    testdxfp.cpp
+    testmapconversion.cpp)
 
 include_directories("../ThirdParty/Catch" "../ThirdParty/FakeIt")
 

--- a/salaTest/testmapconversion.cpp
+++ b/salaTest/testmapconversion.cpp
@@ -1,0 +1,206 @@
+// Copyright (C) 2020 Petros Koutsolampros
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "catch.hpp"
+#include "salalib/mapconverter.h"
+#include "salalib/mgraph.h"
+
+TEST_CASE("Failing empty drawing map conversion", "") {
+    std::vector<SpacePixelFile> drawingFiles;
+    REQUIRE_THROWS_WITH(MapConverter::convertDrawingToAxial(nullptr, "Axial map", drawingFiles),
+                        Catch::Contains("Failed to convert lines"));
+    REQUIRE_THROWS_WITH(MapConverter::convertDrawingToSegment(nullptr, "Segment map", drawingFiles),
+                        Catch::Contains("No lines found in drawing"));
+    REQUIRE_THROWS_WITH(MapConverter::convertDrawingToConvex(nullptr, "Convex map", drawingFiles),
+                        Catch::Contains("No polygons found in drawing"));
+
+    drawingFiles.push_back(SpacePixelFile("Drawing file"));
+    REQUIRE_THROWS_WITH(MapConverter::convertDrawingToAxial(nullptr, "Axial map", drawingFiles),
+                        Catch::Contains("Failed to convert lines"));
+    REQUIRE_THROWS_WITH(MapConverter::convertDrawingToSegment(nullptr, "Segment map", drawingFiles),
+                        Catch::Contains("No lines found in drawing"));
+    REQUIRE_THROWS_WITH(MapConverter::convertDrawingToConvex(nullptr, "Convex map", drawingFiles),
+                        Catch::Contains("No polygons found in drawing"));
+
+    drawingFiles.back().m_spacePixels.push_back(ShapeMap("Drawing layer", ShapeMap::DRAWINGMAP));
+    REQUIRE_THROWS_WITH(MapConverter::convertDrawingToAxial(nullptr, "Axial map", drawingFiles),
+                        Catch::Contains("Failed to convert lines"));
+    REQUIRE_THROWS_WITH(MapConverter::convertDrawingToSegment(nullptr, "Segment map", drawingFiles),
+                        Catch::Contains("No lines found in drawing"));
+    REQUIRE_THROWS_WITH(MapConverter::convertDrawingToConvex(nullptr, "Convex map", drawingFiles),
+                        Catch::Contains("No polygons found in drawing"));
+}
+
+TEST_CASE("Failing empty axial to segment map conversion", "") {
+    ShapeGraph segmentMap("Axial map", ShapeMap::AXIALMAP);
+    // TODO: Does not throw an exception but maybe it should as the axial map is empty?
+    // REQUIRE_THROWS_WITH(MapConverter::convertAxialToSegment(nullptr, segmentMap, "Segment map", false, false, 0),
+    // Catch::Contains("No lines found in drawing"));
+}
+
+TEST_CASE("Failing empty data map conversion", "") {
+    ShapeMap dataMap("Data map", ShapeMap::DATAMAP);
+    REQUIRE_THROWS_WITH(MapConverter::convertDataToAxial(nullptr, "Axial map", dataMap),
+                        Catch::Contains("No lines found in data map"));
+    REQUIRE_THROWS_WITH(MapConverter::convertDataToSegment(nullptr, "Segment map", dataMap),
+                        Catch::Contains("No lines found in data map"));
+    REQUIRE_THROWS_WITH(MapConverter::convertDataToConvex(nullptr, "Convex map", dataMap),
+                        Catch::Contains("No polygons found in data map"));
+}
+
+TEST_CASE("Test drawing to segment conversion", "") {
+    const float EPSILON = 0.001;
+
+    Line line1(Point2f(0, 0), Point2f(0, 1));
+    Line line2(Point2f(0, 1), Point2f(1, 1));
+    Line line3(Point2f(1, 1), Point2f(1, 0));
+
+    std::vector<SpacePixelFile> drawingFiles;
+    drawingFiles.push_back(SpacePixelFile("Drawing file"));
+    drawingFiles.back().m_spacePixels.push_back(ShapeMap("Drawing layer", ShapeMap::DRAWINGMAP));
+    ShapeMap &drawingLayer = drawingFiles.back().m_spacePixels.back();
+
+    SECTION("Single line") {
+        drawingLayer.makeLineShape(line1);
+
+        // TODO: This fails with std::bad_alloc because there's only 1 line in the drawing
+        REQUIRE_THROWS_WITH(MapConverter::convertDrawingToSegment(nullptr, "Segment map", drawingFiles),
+                            Catch::Contains("std::bad_alloc"));
+    }
+
+    SECTION("Two lines") {
+        drawingLayer.makeLineShape(line1);
+        drawingLayer.makeLineShape(line2);
+
+        // TODO: This fails with std::bad_alloc because there's only 2 lines in the drawing
+        REQUIRE_THROWS_WITH(MapConverter::convertDrawingToSegment(nullptr, "Segment map", drawingFiles),
+                            Catch::Contains("std::bad_alloc"));
+    }
+
+    SECTION("Three lines") {
+        drawingLayer.makeLineShape(line1);
+        drawingLayer.makeLineShape(line2);
+        drawingLayer.makeLineShape(line3);
+        std::unique_ptr<ShapeGraph> segmentMap =
+            MapConverter::convertDrawingToSegment(nullptr, "Segment map", drawingFiles);
+        std::map<int, SalaShape> &shapes = segmentMap->getAllShapes();
+        REQUIRE(shapes.size() == 3);
+        auto shapeIter = shapes.begin();
+        REQUIRE(shapeIter->first == 0);
+        const Line &segmentLine1 = shapeIter->second.getLine();
+        REQUIRE(segmentLine1.ax() == Approx(line1.ax()).epsilon(EPSILON));
+        REQUIRE(segmentLine1.ay() == Approx(line1.ay()).epsilon(EPSILON));
+        REQUIRE(segmentLine1.bx() == Approx(line1.bx()).epsilon(EPSILON));
+        REQUIRE(segmentLine1.by() == Approx(line1.by()).epsilon(EPSILON));
+        shapeIter++;
+        REQUIRE(shapeIter->first == 1);
+        const Line &segmentLine2 = shapeIter->second.getLine();
+        REQUIRE(segmentLine2.ax() == Approx(line2.ax()).epsilon(EPSILON));
+        REQUIRE(segmentLine2.ay() == Approx(line2.ay()).epsilon(EPSILON));
+        REQUIRE(segmentLine2.bx() == Approx(line2.bx()).epsilon(EPSILON));
+        REQUIRE(segmentLine2.by() == Approx(line2.by()).epsilon(EPSILON));
+        shapeIter++;
+        REQUIRE(shapeIter->first == 2);
+        const Line &segmentLine3 = shapeIter->second.getLine();
+        REQUIRE(segmentLine3.ax() == Approx(line3.ax()).epsilon(EPSILON));
+        REQUIRE(segmentLine3.ay() == Approx(line3.ay()).epsilon(EPSILON));
+        REQUIRE(segmentLine3.bx() == Approx(line3.bx()).epsilon(EPSILON));
+        REQUIRE(segmentLine3.by() == Approx(line3.by()).epsilon(EPSILON));
+    }
+}
+
+TEST_CASE("Test data to segment conversion", "") {
+    const float EPSILON = 0.001;
+
+    std::string newAttributeName = "testID";
+    ShapeMap dataMap("Data map", ShapeMap::DATAMAP);
+    int newAttributeID = dataMap.addAttribute(newAttributeName);
+
+    std::vector<Line> lines;
+    std::vector<std::map<int, float>> extraAttributes;
+
+    lines.push_back(Line(Point2f(0, 0), Point2f(0, 1)));
+    lines.push_back(Line(Point2f(0, 1), Point2f(1, 1)));
+    lines.push_back(Line(Point2f(1, 1), Point2f(1, 0)));
+
+    for (int i = 0; i < lines.size(); i++) {
+        extraAttributes.push_back(std::map<int, float>());
+        extraAttributes.back()[newAttributeID] = extraAttributes.size();
+    }
+
+    SECTION("Single line with extra attributes") {
+        dataMap.makeLineShape(lines[0], false, false, extraAttributes[0]);
+
+        // TODO: This fails with std::bad_alloc because there's only 1 line in the data map
+        REQUIRE_THROWS_WITH(MapConverter::convertDataToSegment(nullptr, "Segment map", dataMap, true),
+                            Catch::Contains("std::bad_alloc"));
+    }
+
+    SECTION("Two lines with extra attributes") {
+        dataMap.makeLineShape(lines[0], false, false, extraAttributes[0]);
+        dataMap.makeLineShape(lines[1], false, false, extraAttributes[1]);
+
+        // TODO: This fails with std::bad_alloc because there's only 2 lines in the data map
+        REQUIRE_THROWS_WITH(MapConverter::convertDataToSegment(nullptr, "Segment map", dataMap, true),
+                            Catch::Contains("std::bad_alloc"));
+    }
+
+    SECTION("Three lines") {
+        dataMap.makeLineShape(lines[0], false, false, extraAttributes[0]);
+        dataMap.makeLineShape(lines[1], false, false, extraAttributes[1]);
+        dataMap.makeLineShape(lines[2], false, false, extraAttributes[2]);
+        std::unique_ptr<ShapeGraph> segmentMap =
+            MapConverter::convertDataToSegment(nullptr, "Segment map", dataMap, true);
+        int segmentNewAttributeID = segmentMap->getAttributeTable().getColumnIndex(newAttributeName);
+        std::map<int, SalaShape> &shapes = segmentMap->getAllShapes();
+        REQUIRE(shapes.size() == 3);
+        auto shapeIter = shapes.begin();
+        for (int i = 0; i < lines.size(); i++) {
+            REQUIRE(shapeIter->first == i);
+            AttributeRow &row = segmentMap->getAttributeRowFromShapeIndex(shapeIter->first);
+            REQUIRE(row.getValue(segmentNewAttributeID) == extraAttributes[i][newAttributeID]);
+            const Line &segmentLine = shapeIter->second.getLine();
+            REQUIRE(segmentLine.ax() == Approx(lines[i].ax()).epsilon(EPSILON));
+            REQUIRE(segmentLine.ay() == Approx(lines[i].ay()).epsilon(EPSILON));
+            REQUIRE(segmentLine.bx() == Approx(lines[i].bx()).epsilon(EPSILON));
+            REQUIRE(segmentLine.by() == Approx(lines[i].by()).epsilon(EPSILON));
+            shapeIter++;
+        }
+    }
+
+    SECTION("Four lines, second line twice") {
+        dataMap.makeLineShape(lines[0], false, false, extraAttributes[0]);
+        dataMap.makeLineShape(lines[1], false, false, extraAttributes[1]);
+        dataMap.makeLineShape(lines[1], false, false, extraAttributes[1]); // this one should be removed by tidylines
+        dataMap.makeLineShape(lines[2], false, false, extraAttributes[2]);
+        std::unique_ptr<ShapeGraph> segmentMap =
+            MapConverter::convertDataToSegment(nullptr, "Segment map", dataMap, true);
+        int segmentNewAttributeID = segmentMap->getAttributeTable().getColumnIndex(newAttributeName);
+        std::map<int, SalaShape> &shapes = segmentMap->getAllShapes();
+        REQUIRE(shapes.size() == 3);
+        auto shapeIter = shapes.begin();
+        for (int i = 0; i < lines.size(); i++) {
+            REQUIRE(shapeIter->first == i);
+            AttributeRow &row = segmentMap->getAttributeRowFromShapeIndex(shapeIter->first);
+            REQUIRE(row.getValue(segmentNewAttributeID) == extraAttributes[i][newAttributeID]);
+            const Line &segmentLine = shapeIter->second.getLine();
+            REQUIRE(segmentLine.ax() == Approx(lines[i].ax()).epsilon(EPSILON));
+            REQUIRE(segmentLine.ay() == Approx(lines[i].ay()).epsilon(EPSILON));
+            REQUIRE(segmentLine.bx() == Approx(lines[i].bx()).epsilon(EPSILON));
+            REQUIRE(segmentLine.by() == Approx(lines[i].by()).epsilon(EPSILON));
+            shapeIter++;
+        }
+    }
+}

--- a/salalib/mapconverter.cpp
+++ b/salalib/mapconverter.cpp
@@ -54,7 +54,7 @@ std::unique_ptr<ShapeGraph> MapConverter::convertDrawingToAxial(Communicator *co
 
     // quick tidy removes very short and duplicate lines, but does not merge overlapping lines
     TidyLines tidier;
-    tidier.quicktidy(lines, region);
+    tidier.quicktidy(lines, layers, region);
     if (lines.size() == 0) {
         throw depthmapX::RuntimeException("No lines found after removing short and duplicates");
     }
@@ -125,7 +125,7 @@ std::unique_ptr<ShapeGraph> MapConverter::convertDataToAxial(Communicator *comm,
 
    // quick tidy removes very short and duplicate lines, but does not merge overlapping lines
    TidyLines tidier;
-   tidier.quicktidy(lines, region);
+   tidier.quicktidy(lines, keys, region);
    if (lines.size() == 0) {
        throw depthmapX::RuntimeException("No lines found after removing short and duplicates");
    }
@@ -336,7 +336,7 @@ std::unique_ptr<ShapeGraph> MapConverter::convertDrawingToSegment(Communicator *
 
    // quick tidy removes very short and duplicate lines, but does not merge overlapping lines
    TidyLines tidier;
-   tidier.quicktidy(lines, region);
+   tidier.quicktidy(lines, layers, region);
    if (lines.size() == 0) {
        throw depthmapX::RuntimeException("No lines found after removing short and duplicates");
    }
@@ -405,7 +405,7 @@ std::unique_ptr<ShapeGraph> MapConverter::convertDataToSegment(Communicator *com
 
    // quick tidy removes very short and duplicate lines, but does not merge overlapping lines
    TidyLines tidier;
-   tidier.quicktidy(lines, region);
+   tidier.quicktidy(lines, keys, region);
 
    if (lines.size() == 0) {
        throw depthmapX::RuntimeException("No lines found after removing short and duplicates");

--- a/salalib/tidylines.cpp
+++ b/salalib/tidylines.cpp
@@ -72,7 +72,7 @@ void TidyLines::tidy(std::vector<Line>& lines, const QtRegion& region)
    removelist.clear();  // always clear this list, it's reused
 }
 
-void TidyLines::quicktidy(std::map<int,Line>& lines, const QtRegion& region)
+void TidyLines::quicktidy(std::map<int, Line>& lines, std::map<int, int>& keys, const QtRegion& region)
 {
    m_region = region;
 
@@ -86,11 +86,14 @@ void TidyLines::quicktidy(std::map<int,Line>& lines, const QtRegion& region)
    double tolerance = avglen * 10e-6;
 
    auto iter = lines.begin(), end = lines.end();
+   auto keyIter  = keys.begin();
    for(; iter != end; ) {
        if (iter->second.length() < tolerance) {
            iter = lines.erase(iter);
+           keyIter = keys.erase(keyIter);
        } else {
            ++iter;
+           ++keyIter;
        }
    }
 
@@ -119,6 +122,7 @@ void TidyLines::quicktidy(std::map<int,Line>& lines, const QtRegion& region)
    }
    for(int remove: removelist) {
        lines.erase(remove);
+       keys.erase(remove);
    }
    removelist.clear(); // always clear this list, it's reused}
 }

--- a/salalib/tidylines.cpp
+++ b/salalib/tidylines.cpp
@@ -72,35 +72,32 @@ void TidyLines::tidy(std::vector<Line>& lines, const QtRegion& region)
    removelist.clear();  // always clear this list, it's reused
 }
 
-void TidyLines::quicktidy(std::map<int, Line>& lines, std::map<int, int>& keys, const QtRegion& region)
+void TidyLines::quicktidy(std::map<int, std::pair<Line, int>>& lines, const QtRegion& region)
 {
    m_region = region;
 
    double avglen = 0.0;
 
    for (auto line: lines) {
-      avglen += line.second.length();
+      avglen += line.second.first.length();
    }
    avglen /= lines.size();
 
    double tolerance = avglen * 10e-6;
 
    auto iter = lines.begin(), end = lines.end();
-   auto keyIter  = keys.begin();
    for(; iter != end; ) {
-       if (iter->second.length() < tolerance) {
+       if (iter->second.first.length() < tolerance) {
            iter = lines.erase(iter);
-           keyIter = keys.erase(keyIter);
        } else {
            ++iter;
-           ++keyIter;
        }
    }
 
    // now load up m_lines...
    initLines(lines.size(),m_region.bottom_left,m_region.top_right);
    for (auto line: lines) {
-      addLine(line.second);
+      addLine(line.second.first);
    }
    sortPixelLines();
 
@@ -109,7 +106,7 @@ void TidyLines::quicktidy(std::map<int, Line>& lines, std::map<int, int>& keys, 
    int i = -1;
    for (auto line: lines) {
       i++;
-      PixelRef start = pixelate(line.second.start());
+      PixelRef start = pixelate(line.second.first.start());
       auto& pixel_lines = m_pixel_lines(static_cast<size_t>(start.y), static_cast<size_t>(start.x));
       for (int k: pixel_lines) {
          if (k > int(i) && approxeq(m_lines[i].line.start(),m_lines[k].line.start(),tolerance)) {
@@ -122,7 +119,6 @@ void TidyLines::quicktidy(std::map<int, Line>& lines, std::map<int, int>& keys, 
    }
    for(int remove: removelist) {
        lines.erase(remove);
-       keys.erase(remove);
    }
    removelist.clear(); // always clear this list, it's reused}
 }

--- a/salalib/tidylines.h
+++ b/salalib/tidylines.h
@@ -10,5 +10,5 @@ class TidyLines : public SpacePixel
 {
 public:
    void tidy(std::vector<Line> &lines, const QtRegion& region);
-   void quicktidy(std::map<int, Line> &lines, std::map<int, int> &keys, const QtRegion& region);
+   void quicktidy(std::map<int, std::pair<Line, int> > &lines, const QtRegion& region);
 };

--- a/salalib/tidylines.h
+++ b/salalib/tidylines.h
@@ -10,5 +10,5 @@ class TidyLines : public SpacePixel
 {
 public:
    void tidy(std::vector<Line> &lines, const QtRegion& region);
-   void quicktidy(std::map<int, Line> &lines, const QtRegion& region);
+   void quicktidy(std::map<int, Line> &lines, std::map<int, int> &keys, const QtRegion& region);
 };


### PR DESCRIPTION
The problem is created when importing a mif/mid file, which creates a data map and then converting the data map to a segment/axial map. If the data map contained small and duplicate lines they will be removed but their keys are not also cleaned up, and therefore we end up with a mismatch between data-map data and segment map data.