### PR TITLE
Allow the OpenGL window and related objects to use OpenGL ES

### DIFF
--- a/depthmapX/main.cpp
+++ b/depthmapX/main.cpp
@@ -24,7 +24,6 @@
 #include <windows.h>
 #endif
 
-
 int main(int argc, char *argv[])
 {
     Q_INIT_RESOURCE(resource);

--- a/depthmapX/main.cpp
+++ b/depthmapX/main.cpp
@@ -24,6 +24,7 @@
 #include <windows.h>
 #endif
 
+
 int main(int argc, char *argv[])
 {
     Q_INIT_RESOURCE(resource);

--- a/depthmapX/views/3dview/3dview.cpp
+++ b/depthmapX/views/3dview/3dview.cpp
@@ -224,6 +224,8 @@ void Q3DView::timerEvent(QTimerEvent *event)
 //void Q3DView::Init()
 void Q3DView::initializeGL()
 {
+   initializeOpenGLFunctions();
+
    m_oldRect = QRect(0, 0, width(), height());
 
    glClearDepth(1.0f);

--- a/depthmapX/views/3dview/3dview.h
+++ b/depthmapX/views/3dview/3dview.h
@@ -22,6 +22,8 @@
 #include <QPoint>
 #include <QSize>
 
+#include <QOpenGLFunctions>
+
 #define ID_ADD_AGENT                    32947
 #define ID_3D_PAN                       32948
 #define ID_3D_ZOOM                      32949
@@ -93,7 +95,7 @@ struct C3DPixelData
 
 /////////////////////////////////////////////////////////////////////////////
 
-class Q3DView : public QOpenGLWidget
+class Q3DView : public QOpenGLWidget, protected QOpenGLFunctions
 {
    Q_OBJECT
 

--- a/depthmapX/views/glview/gldynamicline.cpp
+++ b/depthmapX/views/glview/gldynamicline.cpp
@@ -42,7 +42,8 @@ void GLDynamicLine::paintGL(const QMatrix4x4 &m_mProj, const QMatrix4x4 &m_mView
     m_program->setUniformValue(m_diagVertices2DLoc, m_selectionBounds);
 
     m_program->setUniformValue(m_colourVectorLoc, m_colour_stroke);
-    glDrawArrays(GL_LINE_LOOP, 0, vertexCount());
+    QOpenGLFunctions *glFuncs = QOpenGLContext::currentContext()->functions();
+    glFuncs->glDrawArrays(GL_LINE_LOOP, 0, vertexCount());
 
     m_program->release();
 }

--- a/depthmapX/views/glview/gldynamicrect.cpp
+++ b/depthmapX/views/glview/gldynamicrect.cpp
@@ -19,12 +19,14 @@
 static const char *vertexShaderSourceCore =
     "#version 150\n"
     "in float vertexIndex;\n"
-    "int idxx = int(mod(vertexIndex,2.0));\n"
-    "int idxy = int(vertexIndex/2.0);\n"
+    "int idxx;\n"
+    "int idxy;\n"
     "uniform mat2 diagVertices2D;\n"
     "uniform mat4 projMatrix;\n"
     "uniform mat4 mvMatrix;\n"
     "void main() {\n"
+    "   idxx = int(mod(vertexIndex,2.0));\n"
+    "   idxy = int(vertexIndex/2.0);\n"
     "   gl_Position = projMatrix * mvMatrix * vec4(diagVertices2D[0][idxx],diagVertices2D[1][idxy],0,1);\n"
     "}\n";
 
@@ -38,17 +40,19 @@ static const char *fragmentShaderSourceCore =
 
 static const char *vertexShaderSource =
     "attribute float vertexIndex;\n"
-    "int idxx = int(mod(vertexIndex,2.0));\n"
-    "int idxy = int(vertexIndex/2.0);\n"
+    "int idxx;\n"
+    "int idxy;\n"
     "uniform mat2 diagVertices2D;\n"
     "uniform mat4 projMatrix;\n"
     "uniform mat4 mvMatrix;\n"
     "void main() {\n"
+    "   idxx = int(mod(vertexIndex,2.0));\n"
+    "   idxy = int(vertexIndex/2.0);\n"
     "   gl_Position = projMatrix * mvMatrix * vec4(diagVertices2D[0][idxx],diagVertices2D[1][idxy],0,1);\n"
     "}\n";
 
 static const char *fragmentShaderSource =
-    "uniform vec4 colourVector;\n"
+    "uniform highp vec4 colourVector;\n"
     "void main() {\n"
     "   gl_FragColor = colourVector;\n"
     "}\n";
@@ -153,10 +157,11 @@ void GLDynamicRect::paintGL(const QMatrix4x4 &m_mProj, const QMatrix4x4 &m_mView
     m_program->setUniformValue(m_diagVertices2DLoc, m_selectionBounds);
 
     m_program->setUniformValue(m_colourVectorLoc, m_colour_fill);
-    glDrawArrays(GL_TRIANGLE_FAN, 0, vertexCount());
+    QOpenGLFunctions *glFuncs = QOpenGLContext::currentContext()->functions();
+    glFuncs->glDrawArrays(GL_TRIANGLE_FAN, 0, vertexCount());
 
     m_program->setUniformValue(m_colourVectorLoc, m_colour_stroke);
-    glDrawArrays(GL_LINE_LOOP, 0, vertexCount());
+    glFuncs->glDrawArrays(GL_LINE_LOOP, 0, vertexCount());
 
     m_program->release();
 }

--- a/depthmapX/views/glview/gllines.cpp
+++ b/depthmapX/views/glview/gllines.cpp
@@ -50,7 +50,7 @@ static const char *vertexShaderSource =
     "}\n";
 
 static const char *fragmentShaderSource =
-    "varying vec3 col;\n"
+    "varying highp vec3 col;\n"
     "void main() {\n"
     "   gl_FragColor = vec4(col, 1.0);\n"
     "}\n";
@@ -158,7 +158,8 @@ void GLLines::paintGL(const QMatrix4x4 &m_mProj, const QMatrix4x4 &m_mView, cons
     m_program->setUniformValue(m_projMatrixLoc, m_mProj);
     m_program->setUniformValue(m_mvMatrixLoc, m_mView * m_mModel);
 
-    glDrawArrays(GL_LINES, 0, vertexCount());
+    QOpenGLFunctions *glFuncs = QOpenGLContext::currentContext()->functions();
+    glFuncs->glDrawArrays(GL_LINES, 0, vertexCount());
 
     m_program->release();
 }

--- a/depthmapX/views/glview/gllinesuniform.cpp
+++ b/depthmapX/views/glview/gllinesuniform.cpp
@@ -43,7 +43,7 @@ static const char *vertexShaderSource =
     "}\n";
 
 static const char *fragmentShaderSource =
-    "uniform vec4 colourVector;\n"
+    "uniform highp vec4 colourVector;\n"
     "void main() {\n"
     "   gl_FragColor = colourVector;\n"
     "}\n";
@@ -157,7 +157,8 @@ void GLLinesUniform::paintGL(const QMatrix4x4 &m_mProj, const QMatrix4x4 &m_mVie
     m_program->setUniformValue(m_projMatrixLoc, m_mProj);
     m_program->setUniformValue(m_mvMatrixLoc, m_mView * m_mModel);
 
-    glDrawArrays(GL_LINES, 0, vertexCount());
+    QOpenGLFunctions *glFuncs = QOpenGLContext::currentContext()->functions();
+    glFuncs->glDrawArrays(GL_LINES, 0, vertexCount());
 
     m_program->release();
 }

--- a/depthmapX/views/glview/glpointmap.h
+++ b/depthmapX/views/glview/glpointmap.h
@@ -48,10 +48,11 @@ public:
     void paintGLOverlay(const QMatrix4x4 &m_mProj, const QMatrix4x4 &m_mView, const QMatrix4x4 &m_mModel)
     {
         if(m_showLinks) {
-            glLineWidth(3);
+            QOpenGLFunctions *glFuncs = QOpenGLContext::currentContext()->functions();
+            glFuncs->glLineWidth(3);
             m_linkLines.paintGL(m_mProj, m_mView, m_mModel);
             m_linkFills.paintGL(m_mProj, m_mView, m_mModel);
-            glLineWidth(1);
+            glFuncs->glLineWidth(1);
         }
     }
     void paintGL(const QMatrix4x4 &m_mProj, const QMatrix4x4 &m_mView, const QMatrix4x4 &m_mModel)

--- a/depthmapX/views/glview/glrastertexture.cpp
+++ b/depthmapX/views/glview/glrastertexture.cpp
@@ -165,10 +165,11 @@ void GLRasterTexture::paintGL(const QMatrix4x4 &m_mProj, const QMatrix4x4 &m_mVi
     m_program->setUniformValue(m_mvMatrixLoc, m_mView * m_mModel);
 
     m_texture.bind();
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    QOpenGLFunctions *glFuncs = QOpenGLContext::currentContext()->functions();
+    glFuncs->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glFuncs->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
-    glDrawArrays(GL_TRIANGLE_FAN, 0, vertexCount());
+    glFuncs->glDrawArrays(GL_TRIANGLE_FAN, 0, vertexCount());
 
     m_program->release();
 }

--- a/depthmapX/views/glview/glshapegraph.h
+++ b/depthmapX/views/glview/glshapegraph.h
@@ -51,12 +51,13 @@ public:
     {
         if(m_showLinks)
         {
-            glLineWidth(3);
+            QOpenGLFunctions *glFuncs = QOpenGLContext::currentContext()->functions();
+            glFuncs->glLineWidth(3);
             m_linkLines.paintGL(m_mProj, m_mView, m_mModel);
             m_linkFills.paintGL(m_mProj, m_mView, m_mModel);
             m_unlinkLines.paintGL(m_mProj, m_mView, m_mModel);
             m_unlinkFills.paintGL(m_mProj, m_mView, m_mModel);
-            glLineWidth(1);
+            glFuncs->glLineWidth(1);
         }
     }
     void paintGL(const QMatrix4x4 &m_mProj, const QMatrix4x4 &m_mView, const QMatrix4x4 &m_mModel)

--- a/depthmapX/views/glview/gltriangles.cpp
+++ b/depthmapX/views/glview/gltriangles.cpp
@@ -47,7 +47,7 @@ static const char *vertexShaderSource =
         "}\n";
 
 static const char *fragmentShaderSource =
-        "varying vec4 fragColour;\n"
+        "varying highp vec4 fragColour;\n"
         "void main() {\n"
         "   gl_FragColor = fragColour;\n"
         "}\n";
@@ -132,7 +132,8 @@ void GLTriangles::paintGL(const QMatrix4x4 &m_mProj, const QMatrix4x4 &m_mView, 
     m_program->setUniformValue(m_projMatrixLoc, m_mProj);
     m_program->setUniformValue(m_mvMatrixLoc, m_mView * m_mModel);
 
-    glDrawArrays(GL_TRIANGLES, 0, vertexCount());
+    QOpenGLFunctions *glFuncs = QOpenGLContext::currentContext()->functions();
+    glFuncs->glDrawArrays(GL_TRIANGLES, 0, vertexCount());
 
     m_program->release();
 }

--- a/depthmapX/views/glview/gltrianglesuniform.cpp
+++ b/depthmapX/views/glview/gltrianglesuniform.cpp
@@ -43,7 +43,7 @@ static const char *vertexShaderSource =
     "}\n";
 
 static const char *fragmentShaderSource =
-    "uniform vec4 colourVector;\n"
+    "uniform highp vec4 colourVector;\n"
     "void main() {\n"
     "   gl_FragColor = colourVector;\n"
     "}\n";
@@ -150,7 +150,8 @@ void GLTrianglesUniform::paintGL(const QMatrix4x4 &m_mProj, const QMatrix4x4 &m_
     m_program->setUniformValue(m_projMatrixLoc, m_mProj);
     m_program->setUniformValue(m_mvMatrixLoc, m_mView * m_mModel);
 
-    glDrawArrays(GL_TRIANGLES, 0, vertexCount());
+    QOpenGLFunctions *glFuncs = QOpenGLContext::currentContext()->functions();
+    glFuncs->glDrawArrays(GL_TRIANGLES, 0, vertexCount());
 
     m_program->release();
 }


### PR DESCRIPTION
This ultimately allows the use of ANGLE for displaying graphics on windows, an implementation of OpengGL ES on directX. In practical terms the changes allow for using the depthmapX glview through Windows desktops without an OpenGL >=2.0 implementation, such as those through Remote Desktop (RDP) while previously the only solution was to switch to the legacy Map view. No special build or configuration parameters should be required, as the current Qt versions (>=5.5, tested on 5.13) dynamically load whatever graphics library is available. This change only affects the glview and not the 3dview (agents), as OpenGL ES does not support the fixed-function pipline (glBegin, glVertex etc.). Thus, glview should be available in both desktop and remote desktop versions of depthmapX, but the 3D view will only be available on local desktops that have a GPU. Other operating systems should are not affected by these changes.

Incidentally, this also fixes VirtualBox glview when the client is a Windows machine. 🥳

More information:

https://wiki.qt.io/Qt_5_on_Windows_ANGLE_and_OpenGL

https://doc.qt.io/qt-5/windows-requirements.html#graphics-drivers

https://en.wikipedia.org/wiki/OpenGL_ES

https://doc.qt.io/qt-5/qopenglfunctions.html#details

[Relevant Travis build](https://travis-ci.org/SpaceGroupUCL/depthmapX/builds/734071389)